### PR TITLE
Notifications

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,5 +41,6 @@
   },
   "[typescriptreact]": {
     "editor.defaultFormatter": "biomejs.biome"
-  }
+  },
+  "js/ts.experimental.useTsgo": true
 }

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -25,6 +25,8 @@ import type * as http from "../http.js";
 import type * as index from "../index.js";
 import type * as invitations from "../invitations.js";
 import type * as migrations from "../migrations.js";
+import type * as notificationCopy from "../notificationCopy.js";
+import type * as notificationSubjects from "../notificationSubjects.js";
 import type * as notifications from "../notifications.js";
 import type * as plans from "../plans.js";
 import type * as polar from "../polar.js";
@@ -59,6 +61,8 @@ declare const fullApi: ApiFromModules<{
   index: typeof index;
   invitations: typeof invitations;
   migrations: typeof migrations;
+  notificationCopy: typeof notificationCopy;
+  notificationSubjects: typeof notificationSubjects;
   notifications: typeof notifications;
   plans: typeof plans;
   polar: typeof polar;

--- a/convex/notificationCopy.ts
+++ b/convex/notificationCopy.ts
@@ -157,9 +157,7 @@ export function buildNotificationCopy(input: NotificationInput): NotificationCop
       return {
         kind: "past_appointment_reminder",
         title: subjects.past_appointment_reminder,
-        description:
-          "Haz tenido una cita hace poco, no olvides marcar su estado final.",
-        href: deepLinks.barberAppointments(),
+          "Has tenido una cita hace poco, no olvides marcar su estado final.",
       };
     }
     case "team_invited": {

--- a/convex/notificationCopy.ts
+++ b/convex/notificationCopy.ts
@@ -76,7 +76,9 @@ export interface NotificationCopy {
   href: string;
 }
 
-export function buildNotificationCopy(input: NotificationInput): NotificationCopy {
+export function buildNotificationCopy(
+  input: NotificationInput,
+): NotificationCopy {
   switch (input.kind) {
     case "appointment_created": {
       const isCustomer = input.sendTo === "customer";
@@ -157,7 +159,9 @@ export function buildNotificationCopy(input: NotificationInput): NotificationCop
       return {
         kind: "past_appointment_reminder",
         title: subjects.past_appointment_reminder,
+        description:
           "Has tenido una cita hace poco, no olvides marcar su estado final.",
+        href: deepLinks.customerAppointments(),
       };
     }
     case "team_invited": {
@@ -186,7 +190,9 @@ export function buildNotificationCopy(input: NotificationInput): NotificationCop
     }
     default: {
       const _exhaustive: never = input;
-      throw new Error(`Unhandled notification kind: ${JSON.stringify(_exhaustive)}`);
+      throw new Error(
+        `Unhandled notification kind: ${JSON.stringify(_exhaustive)}`,
+      );
     }
   }
 }

--- a/convex/notificationCopy.ts
+++ b/convex/notificationCopy.ts
@@ -15,7 +15,7 @@ export const deepLinks = {
   invitation: (code: string) => `${siteUrl()}/invitations/${code}`,
 };
 
-type BaseInput = { barbershopName?: string };
+export type BaseInput = { barbershopName?: string };
 
 export type NotificationInput =
   | {
@@ -202,5 +202,3 @@ export function buildSmsBody(copy: NotificationCopy): string {
   return `${copy.description} Ver detalles: ${copy.href}`;
 }
 
-// Re-export helpers unused by the UI for now but handy from server code.
-export type { BaseInput };

--- a/convex/notificationCopy.ts
+++ b/convex/notificationCopy.ts
@@ -161,7 +161,7 @@ export function buildNotificationCopy(
         title: subjects.past_appointment_reminder,
         description:
           "Has tenido una cita hace poco, no olvides marcar su estado final.",
-        href: deepLinks.customerAppointments(),
+        href: deepLinks.barberAppointments(),
       };
     }
     case "team_invited": {
@@ -201,4 +201,3 @@ export function buildNotificationCopy(
 export function buildSmsBody(copy: NotificationCopy): string {
   return `${copy.description} Ver detalles: ${copy.href}`;
 }
-

--- a/convex/notificationCopy.ts
+++ b/convex/notificationCopy.ts
@@ -1,0 +1,202 @@
+import { subjects } from "./notificationSubjects";
+import type { NotificationKind } from "./schema";
+
+/**
+ * Canonical copy for every end-user notification. A single function builds the
+ * title + description used across in-app, email subjects, and SMS bodies so
+ * the three channels cannot drift out of sync.
+ */
+
+export const siteUrl = () => process.env.SITE_URL ?? "";
+
+export const deepLinks = {
+  customerAppointments: () => `${siteUrl()}/profile?tab=appointments`,
+  barberAppointments: () => `${siteUrl()}/profile/barbershops/appointments`,
+  invitation: (code: string) => `${siteUrl()}/invitations/${code}`,
+};
+
+type BaseInput = { barbershopName?: string };
+
+export type NotificationInput =
+  | {
+      kind: "appointment_created";
+      sendTo: "customer" | "barber";
+      barbershopName?: string;
+    }
+  | {
+      kind: "appointment_cancelled";
+      sendTo: "customer" | "barber";
+      customerName?: string;
+      notes?: string;
+    }
+  | {
+      kind: "appointment_reschedule_request";
+      sendTo: "customer" | "barber";
+    }
+  | {
+      kind: "appointment_reschedule_accepted";
+      sendTo: "customer" | "barber";
+    }
+  | {
+      kind: "appointment_reschedule_denied";
+      sendTo: "customer" | "barber";
+      barbershopName?: string;
+    }
+  | {
+      kind: "appointment_reminder";
+      barbershopName: string;
+    }
+  | {
+      kind: "past_appointment_reminder";
+    }
+  | {
+      kind: "team_invited";
+      barbershopName: string;
+      roleLabel: string;
+    }
+  | {
+      kind: "barber_removed_cancellation";
+      barbershopName: string;
+      barberName: string;
+    }
+  | {
+      kind: "service_deleted_cancellation";
+      barbershopName: string;
+      serviceName: string;
+    };
+
+export interface NotificationCopy {
+  /** Persistent kind stored on the in-app row. */
+  kind: NotificationKind;
+  /** Short title (used as in-app title + email subject). */
+  title: string;
+  /** Longer body (used for in-app description, email body, and SMS prefix). */
+  description: string;
+  /** Role-specific deep link the user should land on when clicking the item. */
+  href: string;
+}
+
+export function buildNotificationCopy(input: NotificationInput): NotificationCopy {
+  switch (input.kind) {
+    case "appointment_created": {
+      const isCustomer = input.sendTo === "customer";
+      return {
+        kind: isCustomer ? "appointment_created" : "barber_appointment_created",
+        title: isCustomer
+          ? subjects.appointment_created
+          : subjects.barber_appointment_created,
+        description: isCustomer
+          ? `Tu cita en ${input.barbershopName ?? "la barbería"} ha sido agendada.`
+          : "Un cliente ha reservado una cita.",
+        href: isCustomer
+          ? deepLinks.customerAppointments()
+          : deepLinks.barberAppointments(),
+      };
+    }
+    case "appointment_cancelled": {
+      const isCustomer = input.sendTo === "customer";
+      const who = input.customerName ?? "El cliente";
+      const base = isCustomer
+        ? "Tu cita ha sido cancelada."
+        : `${who} ha cancelado su cita.`;
+      return {
+        kind: "appointment_cancelled",
+        title: subjects.appointment_cancelled,
+        description: input.notes ? `${base} Motivo: ${input.notes}` : base,
+        href: isCustomer
+          ? deepLinks.customerAppointments()
+          : deepLinks.barberAppointments(),
+      };
+    }
+    case "appointment_reschedule_request": {
+      const isCustomer = input.sendTo === "customer";
+      return {
+        kind: "appointment_reschedule_request",
+        title: subjects.appointment_rescheduled_request,
+        description: `${isCustomer ? "Tu barbero" : "Un cliente"} ha solicitado reagendar una cita.`,
+        href: isCustomer
+          ? deepLinks.customerAppointments()
+          : deepLinks.barberAppointments(),
+      };
+    }
+    case "appointment_reschedule_accepted": {
+      const isCustomer = input.sendTo === "customer";
+      return {
+        kind: "appointment_reschedule_accepted",
+        title: subjects.appointment_rescheduled_accepted,
+        description: "Tu solicitud de reagendamiento ha sido aceptada.",
+        href: isCustomer
+          ? deepLinks.customerAppointments()
+          : deepLinks.barberAppointments(),
+      };
+    }
+    case "appointment_reschedule_denied": {
+      const isCustomer = input.sendTo === "customer";
+      return {
+        kind: "appointment_reschedule_denied",
+        title: isCustomer
+          ? subjects.appointment_cancelled
+          : subjects.appointment_rescheduled_denied,
+        description: isCustomer
+          ? `Tu cita en ${input.barbershopName ?? "la barbería"} ha sido cancelada.`
+          : "Tu solicitud de reagendamiento ha sido rechazada.",
+        href: isCustomer
+          ? deepLinks.customerAppointments()
+          : deepLinks.barberAppointments(),
+      };
+    }
+    case "appointment_reminder": {
+      return {
+        kind: "appointment_reminder",
+        title: subjects.appointment_reminder,
+        description: `Tienes una cita en ~30 minutos en ${input.barbershopName}.`,
+        href: deepLinks.customerAppointments(),
+      };
+    }
+    case "past_appointment_reminder": {
+      return {
+        kind: "past_appointment_reminder",
+        title: subjects.past_appointment_reminder,
+        description:
+          "Haz tenido una cita hace poco, no olvides marcar su estado final.",
+        href: deepLinks.barberAppointments(),
+      };
+    }
+    case "team_invited": {
+      return {
+        kind: "team_invited",
+        title: subjects.team_invited,
+        description: `Has sido invitado a unirte a ${input.barbershopName} como ${input.roleLabel}.`,
+        href: deepLinks.barberAppointments(),
+      };
+    }
+    case "barber_removed_cancellation": {
+      return {
+        kind: "barber_removed_cancellation",
+        title: subjects.appointment_cancelled,
+        description: `Tu cita en ${input.barbershopName} ha sido cancelada porque el barbero ${input.barberName} ya no pertenece a la barbería.`,
+        href: deepLinks.customerAppointments(),
+      };
+    }
+    case "service_deleted_cancellation": {
+      return {
+        kind: "service_deleted_cancellation",
+        title: subjects.appointment_cancelled,
+        description: `Tu cita en ${input.barbershopName} ha sido cancelada porque el servicio "${input.serviceName}" ya no está disponible.`,
+        href: deepLinks.customerAppointments(),
+      };
+    }
+    default: {
+      const _exhaustive: never = input;
+      throw new Error(`Unhandled notification kind: ${JSON.stringify(_exhaustive)}`);
+    }
+  }
+}
+
+/** SMS body = description + short deep link. */
+export function buildSmsBody(copy: NotificationCopy): string {
+  return `${copy.description} Ver detalles: ${copy.href}`;
+}
+
+// Re-export helpers unused by the UI for now but handy from server code.
+export type { BaseInput };

--- a/convex/notificationSubjects.ts
+++ b/convex/notificationSubjects.ts
@@ -1,0 +1,19 @@
+/**
+ * Canonical subjects used as notification titles across email, SMS, and
+ * in-app surfaces. Kept in a standalone module to avoid circular imports with
+ * `notifications.ts`.
+ */
+export const subjects = {
+  appointment_reminder: "Recordatorio de cita",
+  appointment_cancelled: "Cita cancelada",
+  appointment_rescheduled: "Cita reagendada",
+  appointment_rescheduled_request: "Solicitud de reagendamiento",
+  appointment_no_show: "Cita no mostrada",
+  appointment_confirmed: "Cita confirmada",
+  appointment_rescheduled_accepted: "Reagendamiento aceptado",
+  appointment_rescheduled_denied: "Reagendamiento rechazado",
+  appointment_created: "Cita agendada",
+  barber_appointment_created: "Nueva cita en tu barbería",
+  team_invited: "Invitación a unirte a la barbería",
+  past_appointment_reminder: "Recordatorio de cita pasada",
+} satisfies Record<string, string>;

--- a/convex/notifications.ts
+++ b/convex/notifications.ts
@@ -909,6 +909,28 @@ export const list = zQuery({
   },
 });
 
+/** Paginated unread notifications for the "Sin leer" tab in the profile inbox. */
+export const listUnread = zQuery({
+  args: z.object({
+    paginationOpts: convexToZod(paginationOptsValidator),
+  }),
+  handler: async (ctx, args) => {
+    const user = await authComponent.safeGetAuthUser(ctx);
+
+    if (!user?.userId) {
+      return { page: [], isDone: true, continueCursor: "" } as const;
+    }
+
+    return await ctx.db
+      .query("inAppNotifications")
+      .withIndex("by_user_unread", (q) =>
+        q.eq("userId", user.userId!).eq("readAt", undefined),
+      )
+      .order("desc")
+      .paginate(args.paginationOpts);
+  },
+});
+
 /** Count of notifications the current user has not yet read. Used for the bell badge. */
 export const unreadCount = zQuery({
   args: z.object({}),
@@ -964,16 +986,24 @@ export const markAllRead = zMutation({
       throw new ConvexError(errorMessages.unauthorized);
     }
 
-    const unread = await ctx.db
-      .query("inAppNotifications")
-      .withIndex("by_user_unread", (q) =>
-        q.eq("userId", user.userId!).eq("readAt", undefined),
-      )
-      .take(200);
-
+    const BATCH = 200;
     const now = Date.now();
-    for (const row of unread) {
-      await ctx.db.patch(row._id, { readAt: now });
+
+    while (true) {
+      const batch = await ctx.db
+        .query("inAppNotifications")
+        .withIndex("by_user_unread", (q) =>
+          q.eq("userId", user.userId!).eq("readAt", undefined),
+        )
+        .take(BATCH);
+
+      if (batch.length === 0) break;
+
+      for (const row of batch) {
+        await ctx.db.patch(row._id, { readAt: now });
+      }
+
+      if (batch.length < BATCH) break;
     }
   },
 });

--- a/convex/notifications.ts
+++ b/convex/notifications.ts
@@ -924,9 +924,9 @@ export const unreadCount = zQuery({
       .withIndex("by_user_unread", (q) =>
         q.eq("userId", user.userId!).eq("readAt", undefined),
       )
-      .take(100);
+      .take(101);
 
-    return unread.length;
+    return unread.length > 100 ? "99+" : unread.length;
   },
 });
 

--- a/convex/notifications.ts
+++ b/convex/notifications.ts
@@ -1,11 +1,13 @@
+import { paginationOptsValidator } from "convex/server";
 import { ConvexError } from "convex/values";
-import { zid } from "convex-helpers/server/zod4";
+import { convexToZod, zid } from "convex-helpers/server/zod4";
 import { z } from "zod";
 
-import { zInternalMutation } from ".";
+import { zInternalMutation, zMutation, zQuery } from ".";
 import { internal } from "./_generated/api";
-import type { Id } from "./_generated/dataModel";
+import type { Doc, Id } from "./_generated/dataModel";
 import type { MutationCtx } from "./_generated/server";
+import { authComponent } from "./auth";
 import {
   incrementEmailSent,
   incrementSmsSent,
@@ -13,23 +15,16 @@ import {
   isSmsLimitNotExceeded,
 } from "./acl";
 import { errorMessages } from "./errors";
+import {
+  buildNotificationCopy,
+  buildSmsBody,
+  type NotificationCopy,
+} from "./notificationCopy";
+import { subjects } from "./notificationSubjects";
 import type { UserProfileData } from "./schema";
 import { getProfileByUserId } from "./userProfileData";
 
-export const subjects = {
-  appointment_reminder: "Recordatorio de cita",
-  appointment_cancelled: "Cita cancelada",
-  appointment_rescheduled: "Cita reagendada",
-  appointment_rescheduled_request: "Solicitud de reagendamiento",
-  appointment_no_show: "Cita no mostrada",
-  appointment_confirmed: "Cita confirmada",
-  appointment_rescheduled_accepted: "Reagendamiento aceptado",
-  appointment_rescheduled_denied: "Reagendamiento rechazado",
-  appointment_created: "Cita agendada",
-  barber_appointment_created: "Nueva cita en tu barbería",
-  team_invited: "Invitación a unirte a la barbería",
-  past_appointment_reminder: "Recordatorio de cita pasada",
-} satisfies Record<string, string>;
+export { subjects };
 
 export function isNotificationEnabled(
   channel: UserProfileData["notificationsPreferences"][number]["type"],
@@ -115,6 +110,31 @@ async function scheduleEmailWithQuota(
   await send();
 }
 
+/**
+ * Persist an in-app notification row for a specific user. Silently ignored
+ * for guest/unknown recipients so existing SMS + email paths keep working.
+ */
+async function recordInApp(
+  ctx: MutationCtx,
+  opts: {
+    userId: string;
+    copy: NotificationCopy;
+    payload?: Doc<"inAppNotifications">["payload"];
+  },
+): Promise<void> {
+  if (!opts.userId || opts.userId === "user_does_not_exist") {
+    return;
+  }
+
+  await ctx.db.insert("inAppNotifications", {
+    userId: opts.userId,
+    kind: opts.copy.kind,
+    title: opts.copy.title,
+    description: opts.copy.description,
+    payload: opts.payload,
+  });
+}
+
 export const createAppointmentCancelled = zInternalMutation({
   args: z.object({
     customerUserId: z.string(),
@@ -157,17 +177,14 @@ export const createAppointmentCancelled = zInternalMutation({
     const cancellingCustomerName =
       customerProfile?.name ?? appointment.customerName ?? "El cliente";
 
-    const body = isCustomer
-      ? `Tu cita ha sido cancelada.`
-      : `${cancellingCustomerName} ha cancelado su cita.`;
-
-    // Deep link to view appointments
-    const appointmentLink = isCustomer
-      ? `${process.env.SITE_URL}/profile?tab=appointments`
-      : `${process.env.SITE_URL}/profile/barbershops/appointments`;
-
-    let smsBody = args.notes ? `${body} Motivo: ${args.notes}` : body;
-    smsBody = `${smsBody} Ver detalles: ${appointmentLink}`;
+    const copy = buildNotificationCopy({
+      kind: "appointment_cancelled",
+      sendTo: args.sendTo,
+      customerName: cancellingCustomerName,
+      notes: args.notes,
+    });
+    const body = copy.description;
+    const smsBody = buildSmsBody(copy);
 
     const emailEnabled = receiverProfile
       ? isNotificationEnabled("email", receiverProfile.notificationsPreferences)
@@ -196,6 +213,19 @@ export const createAppointmentCancelled = zInternalMutation({
         body: smsBody,
         to: phoneNumber,
         barbershopId: appointment.barbershopId,
+      });
+    }
+
+    if (receiverProfile?.userId) {
+      await recordInApp(ctx, {
+        userId: receiverProfile.userId,
+        copy,
+        payload: {
+          appointmentId: appointment._id,
+          barbershopId: appointment.barbershopId,
+          customerName: cancellingCustomerName,
+          notes: args.notes || undefined,
+        },
       });
     }
   },
@@ -241,21 +271,16 @@ export const createAppointmentRescheduleRequest = zInternalMutation({
       ? resolveCustomerEmail(appointment.contactEmail, customerProfile?.email)
       : barberProfile.email;
 
-    const body = `${isCustomer ? "Tu barbero" : "Un cliente"} ha solicitado reagendar una cita.`;
-
-    // Deep link to view/respond to reschedule request
-    const appointmentLink = isCustomer
-      ? `${process.env.SITE_URL}/profile?tab=appointments`
-      : `${process.env.SITE_URL}/profile/barbershops/appointments`;
-
-    const smsBody = `${body} Responde aquí: ${appointmentLink}`;
+    const copy = buildNotificationCopy({
+      kind: "appointment_reschedule_request",
+      sendTo: args.sendTo,
+    });
+    const body = copy.description;
+    const smsBody = buildSmsBody(copy);
 
     const emailEnabled = isCustomer
       ? isCustomerEmailEnabled(customerProfile)
-      : isNotificationEnabled(
-          "email",
-          receiverProfile.notificationsPreferences,
-        );
+      : isNotificationEnabled("email", barberProfile.notificationsPreferences);
 
     if (emailEnabled && toEmail) {
       await scheduleEmailWithQuota(ctx, appointment.barbershopId, () =>
@@ -279,6 +304,17 @@ export const createAppointmentRescheduleRequest = zInternalMutation({
         body: smsBody,
         to: phoneNumber,
         barbershopId: appointment.barbershopId,
+      });
+    }
+
+    if (receiverProfile?.userId) {
+      await recordInApp(ctx, {
+        userId: receiverProfile.userId,
+        copy,
+        payload: {
+          appointmentId: appointment._id,
+          barbershopId: appointment.barbershopId,
+        },
       });
     }
   },
@@ -307,24 +343,22 @@ export const createAppointmentRescheduleDecision = zInternalMutation({
 
     const appointment = await ctx.db.get(args.appointmentId);
 
-    const acceptedBody = "Tu solicitud de reagendamiento ha sido aceptada.";
-    const deniedBodyForCustomer = `Tu cita en ${args.barbershopName} ha sido cancelada.`;
-    const deniedBodyForBarber =
-      "Tu solicitud de reagendamiento ha sido rechazada.";
+    const copy = buildNotificationCopy(
+      args.accepted
+        ? {
+            kind: "appointment_reschedule_accepted",
+            sendTo: args.role,
+          }
+        : {
+            kind: "appointment_reschedule_denied",
+            sendTo: args.role,
+            barbershopName: args.barbershopName,
+          },
+    );
 
     const isCustomer = args.role === "customer";
-    const body = args.accepted
-      ? acceptedBody
-      : isCustomer
-        ? deniedBodyForCustomer
-        : deniedBodyForBarber;
-
-    // Deep link to view appointments
-    const appointmentLink = isCustomer
-      ? `${process.env.SITE_URL}/profile?tab=appointments`
-      : `${process.env.SITE_URL}/profile/barbershops/appointments`;
-
-    const smsBody = `${body} Ver detalles: ${appointmentLink}`;
+    const body = copy.description;
+    const smsBody = buildSmsBody(copy);
 
     const emailEnabled = receiverProfile
       ? isNotificationEnabled("email", receiverProfile.notificationsPreferences)
@@ -379,6 +413,19 @@ export const createAppointmentRescheduleDecision = zInternalMutation({
         barbershopId: appointment?.barbershopId,
       });
     }
+
+    if (receiverProfile?.userId && appointment) {
+      await recordInApp(ctx, {
+        userId: receiverProfile.userId,
+        copy,
+        payload: {
+          appointmentId: appointment._id,
+          barbershopId: appointment.barbershopId,
+          barbershopName: args.barbershopName,
+          notes: args.notes,
+        },
+      });
+    }
   },
 });
 
@@ -412,24 +459,16 @@ export const createAppointmentCreated = zInternalMutation({
 
     const appointment = await ctx.db.get(args.appointmentId);
 
-    const body = {
-      barber: "Un cliente ha reservado una cita.",
-      customer: `Tu cita en ${args.barbershopName} ha sido agendada.`,
-    };
-
     const isCustomer = args.sendTo === "customer";
     const receiverProfile = isCustomer ? customerProfile : barberProfile;
-    const receiverBody = isCustomer ? body.customer : body.barber;
-    const subject = isCustomer
-      ? subjects.appointment_created
-      : subjects.barber_appointment_created;
-
-    // Deep link to view appointments
-    const appointmentLink = isCustomer
-      ? `${process.env.SITE_URL}/profile?tab=appointments`
-      : `${process.env.SITE_URL}/profile/barbershops/appointments`;
-
-    const smsBody = `${receiverBody} Ver detalles: ${appointmentLink}`;
+    const copy = buildNotificationCopy({
+      kind: "appointment_created",
+      sendTo: args.sendTo,
+      barbershopName: args.barbershopName,
+    });
+    const receiverBody = copy.description;
+    const subject = copy.title;
+    const smsBody = buildSmsBody(copy);
 
     const to = isCustomer
       ? resolveCustomerEmail(args.to, customerProfile?.email)
@@ -484,6 +523,18 @@ export const createAppointmentCreated = zInternalMutation({
         barbershopId: appointment?.barbershopId,
       });
     }
+
+    if (receiverProfile?.userId) {
+      await recordInApp(ctx, {
+        userId: receiverProfile.userId,
+        copy,
+        payload: {
+          appointmentId: args.appointmentId,
+          barbershopId: appointment?.barbershopId,
+          barbershopName: args.barbershopName,
+        },
+      });
+    }
   },
 });
 
@@ -506,11 +557,12 @@ export const createAppointmentReminder = zInternalMutation({
       }
     }
 
-    const body = `Tienes una cita en ~30 minutos en ${args.barbershopName}.`;
-
-    // Deep link to view appointments
-    const appointmentLink = `${process.env.SITE_URL}/profile?tab=appointments`;
-    const smsBody = `${body} Ver detalles: ${appointmentLink}`;
+    const copy = buildNotificationCopy({
+      kind: "appointment_reminder",
+      barbershopName: args.barbershopName,
+    });
+    const body = copy.description;
+    const smsBody = buildSmsBody(copy);
 
     const to = resolveCustomerEmail(args.to, customerProfile?.email);
     const emailEnabled = isCustomerEmailEnabled(customerProfile);
@@ -541,6 +593,17 @@ export const createAppointmentReminder = zInternalMutation({
         barbershopId: args.barbershopId,
       });
     }
+
+    if (customerProfile?.userId) {
+      await recordInApp(ctx, {
+        userId: customerProfile.userId,
+        copy,
+        payload: {
+          barbershopId: args.barbershopId,
+          barbershopName: args.barbershopName,
+        },
+      });
+    }
   },
 });
 
@@ -555,11 +618,8 @@ export const createPastAppointmentReminder = zInternalMutation({
       throw new ConvexError(errorMessages.notFound("perfil de barbero"));
     }
 
-    const body = `Haz tenido una cita hace poco, no olvides marcar su estado final.`;
-
-    // Deep link to appointments management
-    const appointmentLink = `${process.env.SITE_URL}/profile/barbershops/appointments`;
-    const smsBody = `${body} Ver citas: ${appointmentLink}`;
+    const copy = buildNotificationCopy({ kind: "past_appointment_reminder" });
+    const smsBody = buildSmsBody(copy);
 
     if (
       isNotificationEnabled("email", barberProfile.notificationsPreferences)
@@ -582,6 +642,11 @@ export const createPastAppointmentReminder = zInternalMutation({
         to: barberProfile.phoneNumber,
       });
     }
+
+    await recordInApp(ctx, {
+      userId: barberProfile.userId,
+      copy,
+    });
   },
 });
 
@@ -611,8 +676,14 @@ export const createBarberInvited = zInternalMutation({
       ? "recepcionista"
       : "barbero";
 
+    const copy = buildNotificationCopy({
+      kind: "team_invited",
+      barbershopName: barbershop.name,
+      roleLabel,
+    });
+
     await ctx.scheduler.runAfter(0, internal.twilio.sendSms, {
-      body: `Has sido invitado a unirte a ${barbershop.name} como ${roleLabel}. Ver detalles: ${invitationUrl}`,
+      body: `${copy.description} Ver detalles: ${invitationUrl}`,
       to: args.phone,
     });
 
@@ -623,6 +694,24 @@ export const createBarberInvited = zInternalMutation({
       inviterName: inviterProfile?.name ?? undefined,
       expiresLabel: new Date(args.expiresAt).toLocaleDateString("es-ES"),
     });
+
+    // If the invitee already has an account, surface the invite in-app too.
+    const inviteeProfile = await ctx.db
+      .query("userProfileData")
+      .withIndex("by_email", (q) => q.eq("email", args.email))
+      .unique();
+
+    if (inviteeProfile?.userId) {
+      await recordInApp(ctx, {
+        userId: inviteeProfile.userId,
+        copy: { ...copy, href: invitationUrl },
+        payload: {
+          barbershopId: args.barbershopId,
+          barbershopName: barbershop.name,
+          invitationCode: args.code,
+        },
+      });
+    }
   },
 });
 
@@ -644,10 +733,13 @@ export const createBarberRemovedCancellation = zInternalMutation({
 
     const appointment = await ctx.db.get(args.appointmentId);
 
-    const body = `Tu cita en ${args.barbershopName} ha sido cancelada porque el barbero ${args.barberName} ya no pertenece a la barbería.`;
-
-    const appointmentsUrl = `${process.env.SITE_URL}/profile?tab=appointments`;
-    const smsBody = `${body} Ver detalles: ${appointmentsUrl}`;
+    const copy = buildNotificationCopy({
+      kind: "barber_removed_cancellation",
+      barbershopName: args.barbershopName,
+      barberName: args.barberName,
+    });
+    const body = copy.description;
+    const smsBody = buildSmsBody(copy);
 
     const toEmail = resolveCustomerEmail(
       args.contactEmail,
@@ -682,6 +774,19 @@ export const createBarberRemovedCancellation = zInternalMutation({
         barbershopId: appointment?.barbershopId,
       });
     }
+
+    if (customerProfile?.userId) {
+      await recordInApp(ctx, {
+        userId: customerProfile.userId,
+        copy,
+        payload: {
+          appointmentId: args.appointmentId,
+          barbershopId: appointment?.barbershopId,
+          barbershopName: args.barbershopName,
+          barberName: args.barberName,
+        },
+      });
+    }
   },
 });
 
@@ -703,10 +808,13 @@ export const createServiceDeletedCancellation = zInternalMutation({
 
     const appointment = await ctx.db.get(args.appointmentId);
 
-    const body = `Tu cita en ${args.barbershopName} ha sido cancelada porque el servicio "${args.serviceName}" ya no está disponible.`;
-
-    const appointmentsUrl = `${process.env.SITE_URL}/profile?tab=appointments`;
-    const smsBody = `${body} Ver detalles: ${appointmentsUrl}`;
+    const copy = buildNotificationCopy({
+      kind: "service_deleted_cancellation",
+      barbershopName: args.barbershopName,
+      serviceName: args.serviceName,
+    });
+    const body = copy.description;
+    const smsBody = buildSmsBody(copy);
 
     const toEmail = resolveCustomerEmail(
       args.contactEmail,
@@ -740,6 +848,132 @@ export const createServiceDeletedCancellation = zInternalMutation({
         to: phoneNumber,
         barbershopId: appointment?.barbershopId,
       });
+    }
+
+    if (customerProfile?.userId) {
+      await recordInApp(ctx, {
+        userId: customerProfile.userId,
+        copy,
+        payload: {
+          appointmentId: args.appointmentId,
+          barbershopId: appointment?.barbershopId,
+          barbershopName: args.barbershopName,
+          serviceName: args.serviceName,
+        },
+      });
+    }
+  },
+});
+
+/* ------------------------------------------------------------------------- */
+/*  In-app notification inbox — public queries/mutations                     */
+/* ------------------------------------------------------------------------- */
+
+const INBOX_RECENT_LIMIT = 5;
+
+/** Most recent 5 notifications for the current user. Used by the header popover. */
+export const listRecent = zQuery({
+  args: z.object({}),
+  handler: async (ctx) => {
+    const user = await authComponent.safeGetAuthUser(ctx);
+
+    if (!user?.userId) {
+      return [];
+    }
+
+    return await ctx.db
+      .query("inAppNotifications")
+      .withIndex("by_user_created", (q) => q.eq("userId", user.userId!))
+      .order("desc")
+      .take(INBOX_RECENT_LIMIT);
+  },
+});
+
+/** Paginated notifications list for the profile "Notificaciones" tab. */
+export const list = zQuery({
+  args: z.object({
+    paginationOpts: convexToZod(paginationOptsValidator),
+  }),
+  handler: async (ctx, args) => {
+    const user = await authComponent.safeGetAuthUser(ctx);
+
+    if (!user?.userId) {
+      return { page: [], isDone: true, continueCursor: "" } as const;
+    }
+
+    return await ctx.db
+      .query("inAppNotifications")
+      .withIndex("by_user_created", (q) => q.eq("userId", user.userId!))
+      .order("desc")
+      .paginate(args.paginationOpts);
+  },
+});
+
+/** Count of notifications the current user has not yet read. Used for the bell badge. */
+export const unreadCount = zQuery({
+  args: z.object({}),
+  handler: async (ctx) => {
+    const user = await authComponent.safeGetAuthUser(ctx);
+
+    if (!user?.userId) {
+      return 0;
+    }
+
+    const unread = await ctx.db
+      .query("inAppNotifications")
+      .withIndex("by_user_unread", (q) =>
+        q.eq("userId", user.userId!).eq("readAt", undefined),
+      )
+      .take(100);
+
+    return unread.length;
+  },
+});
+
+/** Mark a single notification as read. */
+export const markRead = zMutation({
+  args: z.object({
+    id: zid("inAppNotifications"),
+  }),
+  handler: async (ctx, args) => {
+    const user = await authComponent.safeGetAuthUser(ctx);
+
+    if (!user?.userId) {
+      throw new ConvexError(errorMessages.unauthorized);
+    }
+
+    const row = await ctx.db.get(args.id);
+
+    if (!row || row.userId !== user.userId) {
+      throw new ConvexError(errorMessages.unauthorized);
+    }
+
+    if (!row.readAt) {
+      await ctx.db.patch(row._id, { readAt: Date.now() });
+    }
+  },
+});
+
+/** Mark every notification belonging to the current user as read. */
+export const markAllRead = zMutation({
+  args: z.object({}),
+  handler: async (ctx) => {
+    const user = await authComponent.safeGetAuthUser(ctx);
+
+    if (!user?.userId) {
+      throw new ConvexError(errorMessages.unauthorized);
+    }
+
+    const unread = await ctx.db
+      .query("inAppNotifications")
+      .withIndex("by_user_unread", (q) =>
+        q.eq("userId", user.userId!).eq("readAt", undefined),
+      )
+      .take(200);
+
+    const now = Date.now();
+    for (const row of unread) {
+      await ctx.db.patch(row._id, { readAt: now });
     }
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -233,6 +233,47 @@ export const creditPurchases = zodTable("creditPurchases", (id) => ({
   purchasedAt: z.number(),
 }));
 
+export const notificationKinds = [
+  "appointment_created",
+  "barber_appointment_created",
+  "appointment_cancelled",
+  "appointment_reschedule_request",
+  "appointment_reschedule_accepted",
+  "appointment_reschedule_denied",
+  "appointment_reminder",
+  "past_appointment_reminder",
+  "team_invited",
+  "barber_removed_cancellation",
+  "service_deleted_cancellation",
+] as const;
+
+export const notificationKindSchema = z.enum(notificationKinds);
+
+/**
+ * In-app notification inbox rows. One row per recipient; copy is rendered
+ * server-side so SMS, email and in-app stay in sync.
+ */
+export const inAppNotifications = zodTable("inAppNotifications", (id) => ({
+  userId: z.string(),
+  kind: notificationKindSchema,
+  title: z.string(),
+  description: z.string(),
+  payload: z
+    .object({
+      appointmentId: id("appointments").optional(),
+      barbershopId: id("barbershops").optional(),
+      barbershopName: z.string().optional(),
+      barberName: z.string().optional(),
+      customerName: z.string().optional(),
+      serviceName: z.string().optional(),
+      invitationCode: z.string().optional(),
+      notes: z.string().optional(),
+    })
+    .optional(),
+  /** Timestamp at which the recipient marked the row as read; undefined = unread. */
+  readAt: z.number().optional(),
+}));
+
 export default defineSchema({
   userProfileData: userProfileData
     .table()
@@ -304,6 +345,11 @@ export default defineSchema({
     .table()
     .index("by_orderId", ["orderId"])
     .index("by_barbershopId", ["barbershopId"]),
+
+  inAppNotifications: inAppNotifications
+    .table()
+    .index("by_user_created", ["userId"])
+    .index("by_user_unread", ["userId", "readAt"]),
 });
 
 export type UserProfileData = output<typeof userProfileData.schema>;
@@ -329,3 +375,5 @@ export type Invitation = output<typeof invitations.schema>;
 export type Usage = output<typeof usage.schema>;
 export type ExtraCredits = output<typeof extraCredits.schema>;
 export type CreditPurchase = output<typeof creditPurchases.schema>;
+export type InAppNotification = output<typeof inAppNotifications.schema>;
+export type NotificationKind = (typeof notificationKinds)[number];

--- a/emails/emails/appointments/past-appointment-reminder.tsx
+++ b/emails/emails/appointments/past-appointment-reminder.tsx
@@ -36,7 +36,7 @@ export const PastAppointmentReminderEmail = ({
             <Header />
 
             <Text className="mb-4 text-pretty">
-              Haz tenido una cita hace poco, no olvides marcar su estado final.
+              Has tenido una cita hace poco, no olvides marcar su estado final.
             </Text>
 
             <Section className="mb-4 flex w-full items-center justify-center">

--- a/src/components/layout/header/index.tsx
+++ b/src/components/layout/header/index.tsx
@@ -18,6 +18,11 @@ const UserAvatar = lazy(() =>
     default: mod.UserAvatar,
   })),
 );
+const NotificationsBell = lazy(() =>
+  import("@/components/notifications/notifications-bell").then((mod) => ({
+    default: mod.NotificationsBell,
+  })),
+);
 
 export const Header = () => {
   const { routes, user } = useNavRoutes();
@@ -84,6 +89,11 @@ export const Header = () => {
 
         <div className="flex items-center space-x-4">
           <div className="flex items-center space-x-2">
+            {user?.userId ? (
+              <Suspense fallback={<Skeleton className="size-9" />}>
+                <NotificationsBell />
+              </Suspense>
+            ) : null}
             <Suspense fallback={<Skeleton className="size-8" />}>
               {user?.userId ? (
                 <div className="hidden md:block">

--- a/src/components/notifications/appointment-hub-link.ts
+++ b/src/components/notifications/appointment-hub-link.ts
@@ -1,0 +1,32 @@
+/** Search params for `/profile` when opening the customer Citas tab. */
+export type CustomerAppointmentsSearch = { tab: "appointments" };
+
+/** Search params for `/profile/barbershops/appointments` (barber calendar). */
+export type BarberCalendarSearch = { date: number };
+
+function startOfLocalDayMs(referenceMs: number = Date.now()): number {
+  const d = new Date(referenceMs);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+/**
+ * Where to send someone for “everything about appointments”:
+ * - customers → profile Citas tab
+ * - barbers (and staff/owners) → barbershop calendar for today
+ */
+export function getAppointmentHubLink(usesBarberCalendar: boolean): {
+  to: "/profile" | "/profile/barbershops/appointments";
+  search: CustomerAppointmentsSearch | BarberCalendarSearch;
+} {
+  if (usesBarberCalendar) {
+    return {
+      to: "/profile/barbershops/appointments",
+      search: { date: startOfLocalDayMs() },
+    };
+  }
+  return {
+    to: "/profile",
+    search: { tab: "appointments" },
+  };
+}

--- a/src/components/notifications/notification-item.tsx
+++ b/src/components/notifications/notification-item.tsx
@@ -1,0 +1,271 @@
+import type { InAppNotification } from "@convex/schema";
+import { Link } from "@tanstack/react-router";
+import {
+  createContext,
+  type FC,
+  type ReactNode,
+  useContext,
+  useMemo,
+} from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+/**
+ * `NotificationItem` is a compound component. The root provides shared state
+ * (notification row, density, onMarkRead) via context; `Icon`, `Title`,
+ * `Description`, `Meta`, and `Actions` are slots the variant components
+ * compose. This lets each kind tailor its icon, copy emphasis, or quick
+ * actions without adding a growing list of boolean props to the root.
+ */
+
+export type NotificationDensity = "compact" | "comfortable";
+
+export interface NotificationItemContextValue {
+  notification: InAppNotification;
+  density: NotificationDensity;
+  isUnread: boolean;
+  onMarkRead?: (id: InAppNotification["_id"]) => void;
+}
+
+const NotificationItemContext =
+  createContext<NotificationItemContextValue | null>(null);
+
+function useNotificationItem() {
+  const ctx = useContext(NotificationItemContext);
+
+  if (!ctx) {
+    throw new Error("NotificationItem.* must render inside NotificationItem");
+  }
+
+  return ctx;
+}
+
+interface NotificationItemRootProps {
+  notification: InAppNotification;
+  density?: NotificationDensity;
+  onMarkRead?: (id: InAppNotification["_id"]) => void;
+  onSelect?: () => void;
+  children: ReactNode;
+  className?: string;
+}
+
+const NotificationItemRoot: FC<NotificationItemRootProps> = ({
+  notification,
+  density = "comfortable",
+  onMarkRead,
+  onSelect,
+  children,
+  className,
+}) => {
+  const isUnread = !notification.readAt;
+
+  const value = useMemo<NotificationItemContextValue>(
+    () => ({ notification, density, isUnread, onMarkRead }),
+    [notification, density, isUnread, onMarkRead],
+  );
+
+  return (
+    <NotificationItemContext.Provider value={value}>
+      <article
+        data-slot="notification-item"
+        data-unread={isUnread || undefined}
+        data-density={density}
+        onClick={() => {
+          if (isUnread) {
+            onMarkRead?.(notification._id);
+          }
+
+          onSelect?.();
+        }}
+        onKeyDown={(event) => {
+          if (event.key !== "Enter" && event.key !== " ") return;
+          event.preventDefault();
+          if (isUnread) {
+            onMarkRead?.(notification._id);
+          }
+          onSelect?.();
+        }}
+        className={cn(
+          // Base row: relies on CSS vars so light/dark stay coherent.
+          "group/notif relative isolate grid cursor-pointer grid-cols-[auto_1fr_auto] items-start gap-3 rounded-lg border border-transparent bg-transparent px-3 text-left outline-none transition-colors",
+          density === "compact" ? "py-2.5" : "py-3.5",
+          // Subtle inset strip + accent dot for unread rows.
+          "data-unread:border-border/60 data-unread:bg-muted/40",
+          // Hover + focus affordances.
+          "hover:border-border/70 hover:bg-muted/60 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30",
+          className,
+        )}
+      >
+        {children}
+        {/* Unread accent: a thin primary bar hugging the left edge. */}
+        <span
+          aria-hidden="true"
+          className={cn(
+            "pointer-events-none absolute inset-y-2 left-0 w-0.5 rounded-full bg-primary opacity-0 transition-opacity",
+            "group-data-unread/notif:opacity-100",
+          )}
+        />
+      </article>
+    </NotificationItemContext.Provider>
+  );
+};
+
+const NotificationItemIcon: FC<{
+  icon: ReactNode;
+  tone?: "primary" | "warning" | "success" | "destructive" | "muted";
+  className?: string;
+}> = ({ icon, tone = "primary", className }) => {
+  const toneClass = {
+    primary: "bg-primary/10 text-primary",
+    warning: "bg-warning/15 text-warning",
+    success: "bg-success/15 text-success-foreground",
+    destructive: "bg-destructive/10 text-destructive",
+    muted: "bg-muted text-muted-foreground",
+  }[tone];
+
+  return (
+    <span
+      data-slot="notification-icon"
+      className={cn(
+        "mt-0.5 inline-flex size-9 shrink-0 items-center justify-center rounded-full ring-1 ring-border/40 [&_svg]:size-4",
+        toneClass,
+        className,
+      )}
+    >
+      {icon}
+    </span>
+  );
+};
+
+const NotificationItemBody: FC<{ children: ReactNode; className?: string }> = ({
+  children,
+  className,
+}) => (
+  <div
+    data-slot="notification-body"
+    className={cn("flex min-w-0 flex-col gap-0.5", className)}
+  >
+    {children}
+  </div>
+);
+
+const NotificationItemTitle: FC<{
+  children: ReactNode;
+  className?: string;
+}> = ({ children, className }) => {
+  const { density } = useNotificationItem();
+
+  return (
+    <h3
+      data-slot="notification-title"
+      className={cn(
+        "truncate font-medium text-foreground tracking-tight",
+        density === "compact" ? "text-sm" : "text-sm",
+        className,
+      )}
+    >
+      {children}
+    </h3>
+  );
+};
+
+const NotificationItemDescription: FC<{
+  children: ReactNode;
+  className?: string;
+  clamp?: 1 | 2 | 3;
+}> = ({ children, className, clamp = 2 }) => (
+  <p
+    data-slot="notification-description"
+    className={cn(
+      "text-muted-foreground text-xs leading-relaxed",
+      clamp === 1 && "line-clamp-1",
+      clamp === 2 && "line-clamp-2",
+      clamp === 3 && "line-clamp-3",
+      className,
+    )}
+  >
+    {children}
+  </p>
+);
+
+const NotificationItemMeta: FC<{
+  children: ReactNode;
+  className?: string;
+}> = ({ children, className }) => (
+  <span
+    data-slot="notification-meta"
+    className={cn(
+      "inline-flex items-center gap-1 text-[11px] text-muted-foreground/80 tabular-nums tracking-wide",
+      className,
+    )}
+  >
+    {children}
+  </span>
+);
+
+interface NotificationItemActionProps {
+  children: ReactNode;
+  to: string;
+  /** TanStack Router search params for in-app routes (e.g. `tab` or `date`). */
+  search?: Record<string, unknown>;
+  external?: boolean;
+  onClick?: (event: React.MouseEvent) => void;
+}
+
+/**
+ * Quick action button rendered at the trailing edge. Accepts either a
+ * TanStack Router path (relative to the app) or an external absolute URL.
+ */
+const NotificationItemAction: FC<NotificationItemActionProps> = ({
+  children,
+  to,
+  search,
+  external,
+  onClick,
+}) => {
+  const { density } = useNotificationItem();
+  const isExternal = external || /^https?:\/\//.test(to);
+
+  return (
+    <Button
+      size="sm"
+      variant="ghost"
+      nativeButton={false}
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick?.(event);
+      }}
+      render={
+        isExternal ? (
+          <a href={to} target="_blank" rel="noreferrer noopener">
+            {children}
+          </a>
+        ) : (
+          <Link to={to} search={search}>
+            {children}
+          </Link>
+        )
+      }
+      className={cn(
+        "shrink-0 text-primary hover:bg-primary/10 hover:text-primary",
+        // Compact rows (popover) hide the action until hover/focus keeps rows calm.
+        density === "compact" &&
+          "opacity-0 transition-opacity group-focus-within/notif:opacity-100 group-hover/notif:opacity-100 motion-safe:duration-150",
+      )}
+    >
+      {children}
+    </Button>
+  );
+};
+
+export const NotificationItem = Object.assign(NotificationItemRoot, {
+  Icon: NotificationItemIcon,
+  Body: NotificationItemBody,
+  Title: NotificationItemTitle,
+  Description: NotificationItemDescription,
+  Meta: NotificationItemMeta,
+  Action: NotificationItemAction,
+});
+
+export { useNotificationItem };

--- a/src/components/notifications/notification-renderer.tsx
+++ b/src/components/notifications/notification-renderer.tsx
@@ -1,0 +1,63 @@
+import type { InAppNotification } from "@convex/schema";
+import type { FC } from "react";
+
+import { AppointmentNotification } from "./variants/appointment-notification";
+import { CancellationNotification } from "./variants/cancellation-notification";
+import { RescheduleNotification } from "./variants/reschedule-notification";
+import { TeamInviteNotification } from "./variants/team-invite-notification";
+
+export interface NotificationRendererProps {
+  notification: InAppNotification;
+  /** True when the viewer manages appointments from the barbershop calendar (barber, staff, or owner). */
+  usesBarberCalendar: boolean;
+  density?: "compact" | "comfortable";
+  onMarkRead?: (id: InAppNotification["_id"]) => void;
+  onSelect?: () => void;
+}
+
+/**
+ * Dispatches an `InAppNotification` row to the matching family component.
+ * Each family handles its own icon, tone, and quick action, while sharing
+ * the compound `NotificationItem` primitive.
+ */
+export const NotificationRenderer: FC<NotificationRendererProps> = ({
+  notification,
+  usesBarberCalendar,
+  density,
+  onMarkRead,
+  onSelect,
+}) => {
+  const shared = {
+    notification,
+    usesBarberCalendar,
+    density,
+    onMarkRead,
+    onSelect,
+  };
+
+  switch (notification.kind) {
+    case "appointment_created":
+    case "barber_appointment_created":
+    case "appointment_reminder":
+    case "past_appointment_reminder":
+      return <AppointmentNotification {...shared} kind={notification.kind} />;
+
+    case "appointment_cancelled":
+    case "appointment_reschedule_denied":
+    case "barber_removed_cancellation":
+    case "service_deleted_cancellation":
+      return <CancellationNotification {...shared} kind={notification.kind} />;
+
+    case "appointment_reschedule_request":
+    case "appointment_reschedule_accepted":
+      return <RescheduleNotification {...shared} kind={notification.kind} />;
+
+    case "team_invited":
+      return <TeamInviteNotification {...shared} />;
+
+    default: {
+      const _exhaustive: never = notification.kind;
+      return null as never | typeof _exhaustive;
+    }
+  }
+};

--- a/src/components/notifications/notifications-bell.tsx
+++ b/src/components/notifications/notifications-bell.tsx
@@ -38,7 +38,7 @@ export const NotificationsBell = () => {
   const { markReadMutation, markAllReadMutation } = useNotificationActions();
 
   const items = useMemo(() => recent ?? [], [recent]);
-  const hasUnread = unread > 0;
+  const hasUnread = unread !== 0;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -60,7 +60,7 @@ export const NotificationsBell = () => {
                 aria-hidden="true"
                 className="absolute -top-0.5 -right-0.5 inline-flex min-w-4 items-center justify-center rounded-full bg-primary px-1 font-medium text-[10px] text-primary-foreground tabular-nums leading-none ring-2 ring-background"
               >
-                {unread > 9 ? "9+" : unread}
+                {typeof unread === "number" && unread <= 9 ? unread : "9+"}
               </span>
             ) : null}
           </Button>

--- a/src/components/notifications/notifications-bell.tsx
+++ b/src/components/notifications/notifications-bell.tsx
@@ -10,7 +10,6 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Skeleton } from "@/components/ui/skeleton";
 import {
   useIsBarber,
   useIsOwner,
@@ -33,11 +32,11 @@ export const NotificationsBell = () => {
   const { data: isOwner } = useIsOwner(user?.userId ?? "");
   const usesBarberCalendar = Boolean(isBarber || isStaff || isOwner);
 
-  const { data: recent, isLoading } = useRecentNotifications();
-  const { data: unread = 0 } = useUnreadNotificationsCount();
+  const { data: recent } = useRecentNotifications();
+  const { data: unread } = useUnreadNotificationsCount();
   const { markReadMutation, markAllReadMutation } = useNotificationActions();
 
-  const items = useMemo(() => recent ?? [], [recent]);
+  const items = useMemo(() => recent, [recent]);
   const hasUnread = unread !== 0;
 
   return (
@@ -97,20 +96,7 @@ export const NotificationsBell = () => {
 
         <ScrollArea className="max-h-88">
           <div className="flex flex-col gap-0.5 p-1.5">
-            {isLoading ? (
-              ["a", "b", "c"].map((key) => (
-                <div
-                  key={`notif-skeleton-${key}`}
-                  className="flex items-start gap-3 rounded-md px-3 py-3"
-                >
-                  <Skeleton className="size-9 shrink-0 rounded-full" />
-                  <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-                    <Skeleton className="h-3.5 w-1/2" />
-                    <Skeleton className="h-3 w-4/5" />
-                  </div>
-                </div>
-              ))
-            ) : items.length === 0 ? (
+            {items.length === 0 ? (
               <div className="flex flex-col items-center justify-center gap-2 px-4 py-10 text-center">
                 <span className="flex size-10 items-center justify-center rounded-full bg-muted text-muted-foreground">
                   <BellIcon weight="duotone" />

--- a/src/components/notifications/notifications-bell.tsx
+++ b/src/components/notifications/notifications-bell.tsx
@@ -1,0 +1,162 @@
+import { BellIcon, CheckIcon } from "@phosphor-icons/react";
+import { Link } from "@tanstack/react-router";
+import { useMemo, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  useIsBarber,
+  useIsOwner,
+  useIsStaff,
+} from "@/hooks/use-barbershop-members";
+import {
+  useNotificationActions,
+  useRecentNotifications,
+  useUnreadNotificationsCount,
+} from "@/hooks/use-notifications";
+import { useSession } from "@/hooks/use-session";
+
+import { NotificationRenderer } from "./notification-renderer";
+
+export const NotificationsBell = () => {
+  const [open, setOpen] = useState(false);
+  const { data: user } = useSession();
+  const { data: isBarber } = useIsBarber(user?.userId ?? "");
+  const { data: isStaff } = useIsStaff(user?.userId ?? "");
+  const { data: isOwner } = useIsOwner(user?.userId ?? "");
+  const usesBarberCalendar = Boolean(isBarber || isStaff || isOwner);
+
+  const { data: recent, isLoading } = useRecentNotifications();
+  const { data: unread = 0 } = useUnreadNotificationsCount();
+  const { markReadMutation, markAllReadMutation } = useNotificationActions();
+
+  const items = useMemo(() => recent ?? [], [recent]);
+  const hasUnread = unread > 0;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={
+              hasUnread
+                ? `Notificaciones (${unread} sin leer)`
+                : "Notificaciones"
+            }
+            className="relative"
+          >
+            <BellIcon weight={hasUnread ? "fill" : "regular"} />
+            {hasUnread ? (
+              <span
+                aria-hidden="true"
+                className="absolute -top-0.5 -right-0.5 inline-flex min-w-4 items-center justify-center rounded-full bg-primary px-1 font-medium text-[10px] text-primary-foreground tabular-nums leading-none ring-2 ring-background"
+              >
+                {unread > 9 ? "9+" : unread}
+              </span>
+            ) : null}
+          </Button>
+        }
+      />
+
+      <PopoverContent
+        align="end"
+        sideOffset={8}
+        className="w-[min(22rem,calc(100vw-1.5rem))] gap-0 p-0"
+      >
+        <header className="flex items-center justify-between gap-2 border-b px-3 py-2.5">
+          <div className="flex items-center gap-2">
+            <span className="font-medium text-sm tracking-tight">
+              Notificaciones
+            </span>
+            {hasUnread ? (
+              <Badge variant="secondary" className="h-5 px-1.5 text-[11px]">
+                {unread} sin leer
+              </Badge>
+            ) : null}
+          </div>
+          <Button
+            variant="ghost"
+            size="xs"
+            disabled={!hasUnread || markAllReadMutation.isPending}
+            onClick={() => markAllReadMutation.mutate({})}
+            className="gap-1 text-muted-foreground hover:text-foreground"
+          >
+            <CheckIcon />
+            <span className="sr-only sm:not-sr-only">Marcar todas</span>
+          </Button>
+        </header>
+
+        <ScrollArea className="max-h-88">
+          <div className="flex flex-col gap-0.5 p-1.5">
+            {isLoading ? (
+              ["a", "b", "c"].map((key) => (
+                <div
+                  key={`notif-skeleton-${key}`}
+                  className="flex items-start gap-3 rounded-md px-3 py-3"
+                >
+                  <Skeleton className="size-9 shrink-0 rounded-full" />
+                  <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+                    <Skeleton className="h-3.5 w-1/2" />
+                    <Skeleton className="h-3 w-4/5" />
+                  </div>
+                </div>
+              ))
+            ) : items.length === 0 ? (
+              <div className="flex flex-col items-center justify-center gap-2 px-4 py-10 text-center">
+                <span className="flex size-10 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                  <BellIcon weight="duotone" />
+                </span>
+                <div>
+                  <p className="font-medium text-foreground text-sm">
+                    Estás al día
+                  </p>
+                  <p className="text-muted-foreground text-xs">
+                    Aquí verás tus actualizaciones.
+                  </p>
+                </div>
+              </div>
+            ) : (
+              items.map((notification) => (
+                <NotificationRenderer
+                  key={notification._id}
+                  notification={notification}
+                  usesBarberCalendar={usesBarberCalendar}
+                  density="compact"
+                  onMarkRead={(id) => markReadMutation.mutate({ id })}
+                  onSelect={() => setOpen(false)}
+                />
+              ))
+            )}
+          </div>
+        </ScrollArea>
+
+        <footer className="border-t px-2 py-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            nativeButton={false}
+            onClick={() => setOpen(false)}
+            render={
+              <Link
+                to="/profile"
+                search={{ tab: "notifications" }}
+                className="w-full justify-center"
+              />
+            }
+          >
+            Ver todas las notificaciones
+          </Button>
+        </footer>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/src/components/notifications/relative-time.ts
+++ b/src/components/notifications/relative-time.ts
@@ -1,0 +1,92 @@
+/**
+ * Native time-ago formatting powered by `Intl.RelativeTimeFormat`. Follows the
+ * "largest fitting unit" approach described in
+ * https://midu.dev/como-crear-un-time-ago-sin-dependencias-intl-relativeformat/ —
+ * pick the coarsest unit whose threshold has been crossed and let the browser
+ * handle localisation + pluralisation, so we get "hace 1 minuto" / "hace 2 horas"
+ * for free without a date-fns/dayjs dependency.
+ */
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+
+const DATE_UNITS: Array<{
+  unit: Intl.RelativeTimeFormatUnit;
+  ms: number;
+}> = [
+  { unit: "year", ms: 365 * DAY },
+  { unit: "month", ms: 30 * DAY },
+  { unit: "week", ms: WEEK },
+  { unit: "day", ms: DAY },
+  { unit: "hour", ms: HOUR },
+  { unit: "minute", ms: MINUTE },
+  { unit: "second", ms: SECOND },
+];
+
+const relativeFormatter = new Intl.RelativeTimeFormat("es-CO", {
+  numeric: "auto",
+  style: "long",
+});
+
+const shortDateFormatter = new Intl.DateTimeFormat("es-CO", {
+  day: "numeric",
+  month: "short",
+});
+
+const monthYearFormatter = new Intl.DateTimeFormat("es-CO", {
+  month: "long",
+  year: "numeric",
+});
+
+/**
+ * Localised, native relative time (e.g. "hace 5 minutos", "ayer", "hace 2 meses").
+ * Falls back to an absolute short date for anything older than a week so the
+ * label stays informative instead of decaying into "hace 42 días".
+ */
+export function formatRelativeTime(
+  timestamp: number,
+  now: number = Date.now(),
+): string {
+  const delta = now - timestamp;
+  const absDelta = Math.abs(delta);
+
+  if (absDelta < MINUTE) return "ahora";
+
+  if (absDelta >= WEEK) {
+    return shortDateFormatter.format(new Date(timestamp));
+  }
+
+  for (const { unit, ms } of DATE_UNITS) {
+    if (absDelta >= ms) {
+      // Negative value → past ("hace N"), positive → future ("dentro de N").
+      const value = Math.round(-delta / ms);
+      return relativeFormatter.format(value, unit);
+    }
+  }
+
+  return relativeFormatter.format(0, "second");
+}
+
+/**
+ * Bucket a timestamp into "Hoy"/"Ayer"/"Esta semana"/month-year section labels
+ * used by the notifications tab for lightweight date grouping.
+ */
+export function getSectionLabel(
+  timestamp: number,
+  now: number = Date.now(),
+): string {
+  const start = new Date(now);
+  start.setHours(0, 0, 0, 0);
+  const startOfToday = start.getTime();
+  const startOfYesterday = startOfToday - DAY;
+  const startOfWeek = startOfToday - 6 * DAY;
+
+  if (timestamp >= startOfToday) return "Hoy";
+  if (timestamp >= startOfYesterday) return "Ayer";
+  if (timestamp >= startOfWeek) return "Esta semana";
+
+  return monthYearFormatter.format(new Date(timestamp));
+}

--- a/src/components/notifications/variants/appointment-notification.tsx
+++ b/src/components/notifications/variants/appointment-notification.tsx
@@ -1,0 +1,91 @@
+import type { InAppNotification } from "@convex/schema";
+import {
+  CalendarBlankIcon,
+  CalendarCheckIcon,
+  ClockCountdownIcon,
+} from "@phosphor-icons/react";
+import type { FC } from "react";
+
+import { getAppointmentHubLink } from "@/components/notifications/appointment-hub-link";
+import { NotificationItem } from "@/components/notifications/notification-item";
+import { formatRelativeTime } from "@/components/notifications/relative-time";
+
+export interface VariantBaseProps {
+  notification: InAppNotification;
+  /** Barbers, staff, and owners use the barbershop calendar; pure customers use the Citas tab. */
+  usesBarberCalendar: boolean;
+  density?: "compact" | "comfortable";
+  onMarkRead?: (id: InAppNotification["_id"]) => void;
+  onSelect?: () => void;
+}
+
+const customerHub = getAppointmentHubLink(false);
+const barberHub = getAppointmentHubLink(true);
+
+const config = {
+  appointment_created: {
+    tone: "primary" as const,
+    icon: <CalendarCheckIcon weight="duotone" />,
+    actionLabel: "Ver mi cita",
+    /** Only customers receive this kind in-app. */
+    link: customerHub,
+  },
+  barber_appointment_created: {
+    tone: "primary" as const,
+    icon: <CalendarCheckIcon weight="duotone" />,
+    actionLabel: "Ver citas",
+    link: barberHub,
+  },
+  appointment_reminder: {
+    tone: "warning" as const,
+    icon: <ClockCountdownIcon weight="duotone" />,
+    actionLabel: "Ver cita",
+    /** Reminder notifications are only recorded for customers. */
+    link: customerHub,
+  },
+  past_appointment_reminder: {
+    tone: "muted" as const,
+    icon: <CalendarBlankIcon weight="duotone" />,
+    actionLabel: "Marcar estado",
+    /** Past reminders are only for barbers. */
+    link: barberHub,
+  },
+};
+
+export const AppointmentNotification: FC<
+  VariantBaseProps & {
+    kind: keyof typeof config;
+  }
+> = ({
+  notification,
+  density,
+  onMarkRead,
+  onSelect,
+  kind,
+  usesBarberCalendar: _usesBarberCalendar,
+}) => {
+  const { tone, icon, actionLabel, link } = config[kind];
+
+  return (
+    <NotificationItem
+      notification={notification}
+      density={density}
+      onMarkRead={onMarkRead}
+      onSelect={onSelect}
+    >
+      <NotificationItem.Icon icon={icon} tone={tone} />
+      <NotificationItem.Body>
+        <NotificationItem.Title>{notification.title}</NotificationItem.Title>
+        <NotificationItem.Description>
+          {notification.description}
+        </NotificationItem.Description>
+        <NotificationItem.Meta>
+          {formatRelativeTime(notification._creationTime)}
+        </NotificationItem.Meta>
+      </NotificationItem.Body>
+      <NotificationItem.Action to={link.to} search={link.search}>
+        {actionLabel}
+      </NotificationItem.Action>
+    </NotificationItem>
+  );
+};

--- a/src/components/notifications/variants/appointment-notification.tsx
+++ b/src/components/notifications/variants/appointment-notification.tsx
@@ -19,36 +19,33 @@ export interface VariantBaseProps {
   onSelect?: () => void;
 }
 
-const customerHub = getAppointmentHubLink(false);
-const barberHub = getAppointmentHubLink(true);
-
 const config = {
   appointment_created: {
     tone: "primary" as const,
     icon: <CalendarCheckIcon weight="duotone" />,
     actionLabel: "Ver mi cita",
     /** Only customers receive this kind in-app. */
-    link: customerHub,
+    getLink: () => getAppointmentHubLink(false),
   },
   barber_appointment_created: {
     tone: "primary" as const,
     icon: <CalendarCheckIcon weight="duotone" />,
     actionLabel: "Ver citas",
-    link: barberHub,
+    getLink: () => getAppointmentHubLink(true),
   },
   appointment_reminder: {
     tone: "warning" as const,
     icon: <ClockCountdownIcon weight="duotone" />,
     actionLabel: "Ver cita",
     /** Reminder notifications are only recorded for customers. */
-    link: customerHub,
+    getLink: () => getAppointmentHubLink(false),
   },
   past_appointment_reminder: {
     tone: "muted" as const,
     icon: <CalendarBlankIcon weight="duotone" />,
     actionLabel: "Marcar estado",
     /** Past reminders are only for barbers. */
-    link: barberHub,
+    getLink: () => getAppointmentHubLink(true),
   },
 };
 
@@ -64,7 +61,8 @@ export const AppointmentNotification: FC<
   kind,
   usesBarberCalendar: _usesBarberCalendar,
 }) => {
-  const { tone, icon, actionLabel, link } = config[kind];
+  const { tone, icon, actionLabel, getLink } = config[kind];
+  const link = getLink();
 
   return (
     <NotificationItem

--- a/src/components/notifications/variants/cancellation-notification.tsx
+++ b/src/components/notifications/variants/cancellation-notification.tsx
@@ -1,0 +1,72 @@
+import {
+  CalendarXIcon,
+  UserMinusIcon,
+  WarningCircleIcon,
+} from "@phosphor-icons/react";
+import type { FC } from "react";
+
+import { getAppointmentHubLink } from "@/components/notifications/appointment-hub-link";
+import { NotificationItem } from "@/components/notifications/notification-item";
+import { formatRelativeTime } from "@/components/notifications/relative-time";
+
+import type { VariantBaseProps } from "./appointment-notification";
+
+const config = {
+  appointment_cancelled: {
+    tone: "destructive" as const,
+    icon: <CalendarXIcon weight="duotone" />,
+    actionLabel: "Ver citas",
+  },
+  appointment_reschedule_denied: {
+    tone: "destructive" as const,
+    icon: <WarningCircleIcon weight="duotone" />,
+    actionLabel: "Ver detalles",
+  },
+  barber_removed_cancellation: {
+    tone: "destructive" as const,
+    icon: <UserMinusIcon weight="duotone" />,
+    actionLabel: "Ver citas",
+  },
+  service_deleted_cancellation: {
+    tone: "destructive" as const,
+    icon: <WarningCircleIcon weight="duotone" />,
+    actionLabel: "Ver citas",
+  },
+};
+
+export const CancellationNotification: FC<
+  VariantBaseProps & { kind: keyof typeof config }
+> = ({
+  notification,
+  density,
+  onMarkRead,
+  onSelect,
+  kind,
+  usesBarberCalendar,
+}) => {
+  const { tone, icon, actionLabel } = config[kind];
+  const link = getAppointmentHubLink(usesBarberCalendar);
+
+  return (
+    <NotificationItem
+      notification={notification}
+      density={density}
+      onMarkRead={onMarkRead}
+      onSelect={onSelect}
+    >
+      <NotificationItem.Icon icon={icon} tone={tone} />
+      <NotificationItem.Body>
+        <NotificationItem.Title>{notification.title}</NotificationItem.Title>
+        <NotificationItem.Description>
+          {notification.description}
+        </NotificationItem.Description>
+        <NotificationItem.Meta>
+          {formatRelativeTime(notification._creationTime)}
+        </NotificationItem.Meta>
+      </NotificationItem.Body>
+      <NotificationItem.Action to={link.to} search={link.search}>
+        {actionLabel}
+      </NotificationItem.Action>
+    </NotificationItem>
+  );
+};

--- a/src/components/notifications/variants/reschedule-notification.tsx
+++ b/src/components/notifications/variants/reschedule-notification.tsx
@@ -1,0 +1,58 @@
+import { CalendarDotsIcon, CheckCircleIcon } from "@phosphor-icons/react";
+import type { FC } from "react";
+
+import { getAppointmentHubLink } from "@/components/notifications/appointment-hub-link";
+import { NotificationItem } from "@/components/notifications/notification-item";
+import { formatRelativeTime } from "@/components/notifications/relative-time";
+
+import type { VariantBaseProps } from "./appointment-notification";
+
+const config = {
+  appointment_reschedule_request: {
+    tone: "primary" as const,
+    icon: <CalendarDotsIcon weight="duotone" />,
+    actionLabel: "Revisar solicitud",
+  },
+  appointment_reschedule_accepted: {
+    tone: "success" as const,
+    icon: <CheckCircleIcon weight="duotone" />,
+    actionLabel: "Ver cita",
+  },
+};
+
+export const RescheduleNotification: FC<
+  VariantBaseProps & { kind: keyof typeof config }
+> = ({
+  notification,
+  density,
+  onMarkRead,
+  onSelect,
+  kind,
+  usesBarberCalendar,
+}) => {
+  const { tone, icon, actionLabel } = config[kind];
+  const link = getAppointmentHubLink(usesBarberCalendar);
+
+  return (
+    <NotificationItem
+      notification={notification}
+      density={density}
+      onMarkRead={onMarkRead}
+      onSelect={onSelect}
+    >
+      <NotificationItem.Icon icon={icon} tone={tone} />
+      <NotificationItem.Body>
+        <NotificationItem.Title>{notification.title}</NotificationItem.Title>
+        <NotificationItem.Description>
+          {notification.description}
+        </NotificationItem.Description>
+        <NotificationItem.Meta>
+          {formatRelativeTime(notification._creationTime)}
+        </NotificationItem.Meta>
+      </NotificationItem.Body>
+      <NotificationItem.Action to={link.to} search={link.search}>
+        {actionLabel}
+      </NotificationItem.Action>
+    </NotificationItem>
+  );
+};

--- a/src/components/notifications/variants/team-invite-notification.tsx
+++ b/src/components/notifications/variants/team-invite-notification.tsx
@@ -1,0 +1,44 @@
+import { EnvelopeSimpleIcon } from "@phosphor-icons/react";
+import type { FC } from "react";
+
+import { NotificationItem } from "@/components/notifications/notification-item";
+import { formatRelativeTime } from "@/components/notifications/relative-time";
+
+import type { VariantBaseProps } from "./appointment-notification";
+
+export const TeamInviteNotification: FC<VariantBaseProps> = ({
+  notification,
+  density,
+  onMarkRead,
+  onSelect,
+  usesBarberCalendar: _usesBarberCalendar,
+}) => {
+  const code = notification.payload?.invitationCode;
+  const href = code ? `/invitations/${code}` : "/profile";
+
+  return (
+    <NotificationItem
+      notification={notification}
+      density={density}
+      onMarkRead={onMarkRead}
+      onSelect={onSelect}
+    >
+      <NotificationItem.Icon
+        icon={<EnvelopeSimpleIcon weight="duotone" />}
+        tone="primary"
+      />
+      <NotificationItem.Body>
+        <NotificationItem.Title>{notification.title}</NotificationItem.Title>
+        <NotificationItem.Description>
+          {notification.description}
+        </NotificationItem.Description>
+        <NotificationItem.Meta>
+          {formatRelativeTime(notification._creationTime)}
+        </NotificationItem.Meta>
+      </NotificationItem.Body>
+      <NotificationItem.Action to={href}>
+        Abrir invitación
+      </NotificationItem.Action>
+    </NotificationItem>
+  );
+};

--- a/src/components/pricing/pricing-card.tsx
+++ b/src/components/pricing/pricing-card.tsx
@@ -115,6 +115,7 @@ export const PricingCard: FC<PricingCardProps> = ({
               "pointer-events-none opacity-50": hasActiveSubscription,
             })}
             lazy
+            locale="es-CO"
           >
             {hasActiveSubscription
               ? "Cambia tu plan desde el portal"

--- a/src/components/profile/extra-credits-cards.tsx
+++ b/src/components/profile/extra-credits-cards.tsx
@@ -1,6 +1,6 @@
 import { CheckoutLink } from "@convex-dev/polar/react";
+import { api } from "@convex/_generated/api";
 import type { Barbershop, ExtraCredits } from "@convex/schema";
-import { api } from "convex/_generated/api";
 import type { FC } from "react";
 
 import { buttonVariants } from "@/components/ui/button";
@@ -119,6 +119,7 @@ const CreditCard: FC<CreditCardProps> = ({
             metadata={{ barbershopId }}
             className={cn(buttonVariants({ className: "w-full" }))}
             lazy
+            locale="es-CO"
           >
             Comprar créditos
           </CheckoutLink>

--- a/src/components/profile/notifications-tab.tsx
+++ b/src/components/profile/notifications-tab.tsx
@@ -17,6 +17,7 @@ import {
   useNotificationActions,
   useNotificationsPage,
   useUnreadNotificationsCount,
+  useUnreadNotificationsPage,
 } from "@/hooks/use-notifications";
 import { useSession } from "@/hooks/use-session";
 
@@ -35,20 +36,22 @@ export const NotificationsTab = () => {
   const { data: isOwner } = useIsOwner(user?.userId ?? "");
   const usesBarberCalendar = Boolean(isBarber || isStaff || isOwner);
 
-  const { data: page, isLoading } = useNotificationsPage({
+  const { data: allPage, isLoading: isLoadingAll } = useNotificationsPage({
     cursor,
     numItems: PAGE_SIZE,
   });
+  const { data: unreadPage, isLoading: isLoadingUnread } =
+    useUnreadNotificationsPage({ cursor, numItems: PAGE_SIZE });
+
+  const page = filter === "unread" ? unreadPage : allPage;
+  const isLoading = filter === "unread" ? isLoadingUnread : isLoadingAll;
+
   const { data: unread = 0 } = useUnreadNotificationsCount();
   const { markReadMutation, markAllReadMutation } = useNotificationActions();
 
-  const all = useMemo<InAppNotification[]>(
+  const visible = useMemo<InAppNotification[]>(
     () => (page && "page" in page ? (page.page as InAppNotification[]) : []),
     [page],
-  );
-  const visible = useMemo(
-    () => (filter === "unread" ? all.filter((n) => !n.readAt) : all),
-    [all, filter],
   );
 
   // Group into lightweight date buckets for easier scanning.
@@ -95,7 +98,11 @@ export const NotificationsTab = () => {
         <div className="flex flex-wrap items-center gap-2">
           <Tabs
             value={filter}
-            onValueChange={(v) => setFilter(v as NotificationsFilter)}
+            onValueChange={(v) => {
+              setFilter(v as NotificationsFilter);
+              setCursor(null);
+              setCursorStack([]);
+            }}
             orientation="horizontal"
           >
             <TabsList variant="default" className="h-9">

--- a/src/components/profile/notifications-tab.tsx
+++ b/src/components/profile/notifications-tab.tsx
@@ -1,0 +1,202 @@
+import type { InAppNotification } from "@convex/schema";
+import { BellSimpleIcon, CheckIcon, SparkleIcon } from "@phosphor-icons/react";
+import { useMemo, useState } from "react";
+import { ProfileTabSkeleton } from "@/components/layout/skeleton/profile-tab-skeleton";
+import { NotificationRenderer } from "@/components/notifications/notification-renderer";
+import { getSectionLabel } from "@/components/notifications/relative-time";
+import { Button } from "@/components/ui/button";
+import { Empty, EmptyDescription, EmptyTitle } from "@/components/ui/empty";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  useIsBarber,
+  useIsOwner,
+  useIsStaff,
+} from "@/hooks/use-barbershop-members";
+import {
+  useNotificationActions,
+  useNotificationsPage,
+  useUnreadNotificationsCount,
+} from "@/hooks/use-notifications";
+import { useSession } from "@/hooks/use-session";
+
+type NotificationsFilter = "all" | "unread";
+
+const PAGE_SIZE = 20;
+
+export const NotificationsTab = () => {
+  const [filter, setFilter] = useState<NotificationsFilter>("all");
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [cursorStack, setCursorStack] = useState<Array<string | null>>([]);
+
+  const { data: user } = useSession();
+  const { data: isBarber } = useIsBarber(user?.userId ?? "");
+  const { data: isStaff } = useIsStaff(user?.userId ?? "");
+  const { data: isOwner } = useIsOwner(user?.userId ?? "");
+  const usesBarberCalendar = Boolean(isBarber || isStaff || isOwner);
+
+  const { data: page, isLoading } = useNotificationsPage({
+    cursor,
+    numItems: PAGE_SIZE,
+  });
+  const { data: unread = 0 } = useUnreadNotificationsCount();
+  const { markReadMutation, markAllReadMutation } = useNotificationActions();
+
+  const all = useMemo<InAppNotification[]>(
+    () => (page && "page" in page ? (page.page as InAppNotification[]) : []),
+    [page],
+  );
+  const visible = useMemo(
+    () => (filter === "unread" ? all.filter((n) => !n.readAt) : all),
+    [all, filter],
+  );
+
+  // Group into lightweight date buckets for easier scanning.
+  const grouped = useMemo(() => {
+    const buckets = new Map<string, InAppNotification[]>();
+
+    for (const notification of visible) {
+      const label = getSectionLabel(notification._creationTime);
+      const existing = buckets.get(label);
+
+      if (existing) {
+        existing.push(notification);
+      } else {
+        buckets.set(label, [notification]);
+      }
+    }
+
+    return Array.from(buckets.entries());
+  }, [visible]);
+
+  const hasNextPage = Boolean(
+    page && "isDone" in page && !page.isDone && page.continueCursor,
+  );
+  const canGoPrevious = cursorStack.length > 0;
+
+  if (isLoading) {
+    return <ProfileTabSkeleton />;
+  }
+
+  return (
+    <section className="flex flex-col gap-6">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-1">
+          <h2 className="font-semibold text-foreground text-xl tracking-tight">
+            Notificaciones
+          </h2>
+          <p className="text-muted-foreground text-sm">
+            {unread > 0
+              ? `Tienes ${unread} ${unread === 1 ? "notificación nueva" : "notificaciones nuevas"}.`
+              : "Aquí verás tus actualizaciones en tiempo real."}
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Tabs
+            value={filter}
+            onValueChange={(v) => setFilter(v as NotificationsFilter)}
+            orientation="horizontal"
+          >
+            <TabsList variant="default" className="h-9">
+              <TabsTrigger value="all">Todas</TabsTrigger>
+              <TabsTrigger value="unread" className="gap-1.5">
+                Sin leer
+                {unread > 0 ? (
+                  <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1.5 font-medium text-[11px] text-primary-foreground tabular-nums">
+                    {unread > 99 ? "99+" : unread}
+                  </span>
+                ) : null}
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={unread === 0 || markAllReadMutation.isPending}
+            onClick={() => markAllReadMutation.mutate({})}
+          >
+            <CheckIcon />
+            Marcar todas como leídas
+          </Button>
+        </div>
+      </header>
+
+      {visible.length === 0 ? (
+        <Empty className="rounded-xl border border-dashed py-16">
+          <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+            {filter === "unread" ? (
+              <SparkleIcon weight="duotone" />
+            ) : (
+              <BellSimpleIcon weight="duotone" />
+            )}
+          </div>
+          <EmptyTitle>
+            {filter === "unread"
+              ? "No tienes notificaciones sin leer"
+              : "Estás al día"}
+          </EmptyTitle>
+          <EmptyDescription>
+            {filter === "unread"
+              ? "Cuando llegue algo nuevo, aparecerá aquí."
+              : "Las actualizaciones de tus citas aparecerán aquí en cuanto sucedan."}
+          </EmptyDescription>
+        </Empty>
+      ) : (
+        <div className="flex flex-col gap-6">
+          {grouped.map(([label, rows]) => (
+            <div key={label} className="flex flex-col gap-2">
+              <div className="flex items-center gap-3">
+                <h3 className="font-medium text-muted-foreground text-xs uppercase tracking-[0.14em]">
+                  {label}
+                </h3>
+                <div className="h-px flex-1 bg-border/80" />
+              </div>
+              <ul className="flex flex-col gap-1 rounded-xl border border-border/60 bg-card/40 p-1.5">
+                {rows.map((notification) => (
+                  <li key={notification._id}>
+                    <NotificationRenderer
+                      notification={notification}
+                      usesBarberCalendar={usesBarberCalendar}
+                      density="comfortable"
+                      onMarkRead={(id) => markReadMutation.mutate({ id })}
+                    />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <footer className="flex items-center justify-end gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={!canGoPrevious}
+          onClick={() => {
+            setCursorStack((prev) => {
+              const next = [...prev];
+              const previous = next.pop() ?? null;
+              setCursor(previous);
+              return next;
+            });
+          }}
+        >
+          Anterior
+        </Button>
+        <Button
+          size="sm"
+          disabled={!hasNextPage}
+          onClick={() => {
+            if (!page || !("continueCursor" in page)) return;
+            setCursorStack((prev) => [...prev, cursor]);
+            setCursor(page.continueCursor);
+          }}
+        >
+          Siguiente
+        </Button>
+      </footer>
+    </section>
+  );
+};

--- a/src/components/profile/notifications-tab.tsx
+++ b/src/components/profile/notifications-tab.tsx
@@ -1,6 +1,7 @@
 import type { InAppNotification } from "@convex/schema";
 import { BellSimpleIcon, CheckIcon, SparkleIcon } from "@phosphor-icons/react";
-import { useMemo, useState } from "react";
+import type { Dispatch, FC, SetStateAction } from "react";
+import { Suspense, useMemo, useState } from "react";
 
 import { ProfileTabSkeleton } from "@/components/layout/skeleton/profile-tab-skeleton";
 import { NotificationRenderer } from "@/components/notifications/notification-renderer";
@@ -25,36 +26,32 @@ type NotificationsFilter = "all" | "unread";
 
 const PAGE_SIZE = 20;
 
-export const NotificationsTab = () => {
-  const [filter, setFilter] = useState<NotificationsFilter>("all");
-  const [cursor, setCursor] = useState<string | null>(null);
-  const [cursorStack, setCursorStack] = useState<Array<string | null>>([]);
+type PageBodyProps = {
+  cursor: string | null;
+  setCursor: (c: string | null) => void;
+  cursorStack: Array<string | null>;
+  setCursorStack: Dispatch<SetStateAction<Array<string | null>>>;
+  usesBarberCalendar: boolean;
+};
 
-  const { data: user } = useSession();
-  const { data: isBarber } = useIsBarber(user?.userId ?? "");
-  const { data: isStaff } = useIsStaff(user?.userId ?? "");
-  const { data: isOwner } = useIsOwner(user?.userId ?? "");
-  const usesBarberCalendar = Boolean(isBarber || isStaff || isOwner);
-
-  const { data: allPage, isLoading: isLoadingAll } = useNotificationsPage({
+const NotificationsAllPageBody: FC<PageBodyProps> = ({
+  cursor,
+  setCursor,
+  cursorStack,
+  setCursorStack,
+  usesBarberCalendar,
+}) => {
+  const { data: page } = useNotificationsPage({
     cursor,
     numItems: PAGE_SIZE,
   });
-  const { data: unreadPage, isLoading: isLoadingUnread } =
-    useUnreadNotificationsPage({ cursor, numItems: PAGE_SIZE });
-
-  const page = filter === "unread" ? unreadPage : allPage;
-  const isLoading = filter === "unread" ? isLoadingUnread : isLoadingAll;
-
-  const { data: unread = 0 } = useUnreadNotificationsCount();
-  const { markReadMutation, markAllReadMutation } = useNotificationActions();
+  const { markReadMutation } = useNotificationActions();
 
   const visible = useMemo<InAppNotification[]>(
     () => (page && "page" in page ? (page.page as InAppNotification[]) : []),
     [page],
   );
 
-  // Group into lightweight date buckets for easier scanning.
   const grouped = useMemo(() => {
     const buckets = new Map<string, InAppNotification[]>();
 
@@ -77,77 +74,16 @@ export const NotificationsTab = () => {
   );
   const canGoPrevious = cursorStack.length > 0;
 
-  if (isLoading) {
-    return <ProfileTabSkeleton />;
-  }
-
   return (
-    <section className="flex flex-col gap-6">
-      <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex flex-col gap-1">
-          <h2 className="font-semibold text-foreground text-xl tracking-tight">
-            Notificaciones
-          </h2>
-          <p className="text-muted-foreground text-sm">
-            {unread
-              ? `Tienes ${unread} ${unread === 1 ? "notificación nueva" : "notificaciones nuevas"}.`
-              : "Aquí verás tus actualizaciones en tiempo real."}
-          </p>
-        </div>
-
-        <div className="flex flex-wrap items-center gap-2">
-          <Tabs
-            value={filter}
-            onValueChange={(v) => {
-              setFilter(v as NotificationsFilter);
-              setCursor(null);
-              setCursorStack([]);
-            }}
-            orientation="horizontal"
-          >
-            <TabsList variant="default" className="h-9">
-              <TabsTrigger value="all">Todas</TabsTrigger>
-              <TabsTrigger value="unread" className="gap-1.5">
-                Sin leer
-                {unread ? (
-                  <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1.5 font-medium text-[11px] text-primary-foreground tabular-nums">
-                    {unread === 99 || unread === "99+" ? "99+" : unread}
-                  </span>
-                ) : null}
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
-
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={unread === 0 || markAllReadMutation.isPending}
-            onClick={() => markAllReadMutation.mutate({})}
-          >
-            <CheckIcon />
-            Marcar todas como leídas
-          </Button>
-        </div>
-      </header>
-
+    <>
       {visible.length === 0 ? (
         <Empty className="rounded-xl border border-dashed py-16">
           <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
-            {filter === "unread" ? (
-              <SparkleIcon weight="duotone" />
-            ) : (
-              <BellSimpleIcon weight="duotone" />
-            )}
+            <BellSimpleIcon weight="duotone" />
           </div>
-          <EmptyTitle>
-            {filter === "unread"
-              ? "No tienes notificaciones sin leer"
-              : "Estás al día"}
-          </EmptyTitle>
+          <EmptyTitle>Estás al día</EmptyTitle>
           <EmptyDescription>
-            {filter === "unread"
-              ? "Cuando llegue algo nuevo, aparecerá aquí."
-              : "Las actualizaciones de tus citas aparecerán aquí en cuanto sucedan."}
+            Las actualizaciones de tus citas aparecerán aquí en cuanto sucedan.
           </EmptyDescription>
         </Empty>
       ) : (
@@ -205,6 +141,199 @@ export const NotificationsTab = () => {
           Siguiente
         </Button>
       </footer>
+    </>
+  );
+};
+
+const NotificationsUnreadPageBody: FC<PageBodyProps> = ({
+  cursor,
+  setCursor,
+  cursorStack,
+  setCursorStack,
+  usesBarberCalendar,
+}) => {
+  const { data: page } = useUnreadNotificationsPage({
+    cursor,
+    numItems: PAGE_SIZE,
+  });
+  const { markReadMutation } = useNotificationActions();
+
+  const visible = useMemo<InAppNotification[]>(
+    () => (page && "page" in page ? (page.page as InAppNotification[]) : []),
+    [page],
+  );
+
+  const grouped = useMemo(() => {
+    const buckets = new Map<string, InAppNotification[]>();
+
+    for (const notification of visible) {
+      const label = getSectionLabel(notification._creationTime);
+      const existing = buckets.get(label);
+
+      if (existing) {
+        existing.push(notification);
+      } else {
+        buckets.set(label, [notification]);
+      }
+    }
+
+    return Array.from(buckets.entries());
+  }, [visible]);
+
+  const hasNextPage = Boolean(
+    page && "isDone" in page && !page.isDone && page.continueCursor,
+  );
+  const canGoPrevious = cursorStack.length > 0;
+
+  return (
+    <>
+      {visible.length === 0 ? (
+        <Empty className="rounded-xl border border-dashed py-16">
+          <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+            <SparkleIcon weight="duotone" />
+          </div>
+          <EmptyTitle>No tienes notificaciones sin leer</EmptyTitle>
+          <EmptyDescription>
+            Cuando llegue algo nuevo, aparecerá aquí.
+          </EmptyDescription>
+        </Empty>
+      ) : (
+        <div className="flex flex-col gap-6">
+          {grouped.map(([label, rows]) => (
+            <div key={label} className="flex flex-col gap-2">
+              <div className="flex items-center gap-3">
+                <h3 className="font-medium text-muted-foreground text-xs uppercase tracking-[0.14em]">
+                  {label}
+                </h3>
+                <div className="h-px flex-1 bg-border/80" />
+              </div>
+              <ul className="flex flex-col gap-1 rounded-xl border border-border/60 bg-card/40 p-1.5">
+                {rows.map((notification) => (
+                  <li key={notification._id}>
+                    <NotificationRenderer
+                      notification={notification}
+                      usesBarberCalendar={usesBarberCalendar}
+                      density="comfortable"
+                      onMarkRead={(id) => markReadMutation.mutate({ id })}
+                    />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <footer className="flex items-center justify-end gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={!canGoPrevious}
+          onClick={() => {
+            setCursorStack((prev) => {
+              const next = [...prev];
+              const previous = next.pop() ?? null;
+              setCursor(previous);
+              return next;
+            });
+          }}
+        >
+          Anterior
+        </Button>
+        <Button
+          size="sm"
+          disabled={!hasNextPage}
+          onClick={() => {
+            if (!page || !("continueCursor" in page)) return;
+            setCursorStack((prev) => [...prev, cursor]);
+            setCursor(page.continueCursor);
+          }}
+        >
+          Siguiente
+        </Button>
+      </footer>
+    </>
+  );
+};
+
+export const NotificationsTab = () => {
+  const [filter, setFilter] = useState<NotificationsFilter>("all");
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [cursorStack, setCursorStack] = useState<Array<string | null>>([]);
+
+  const { data: user } = useSession();
+  const { data: isBarber } = useIsBarber(user?.userId ?? "");
+  const { data: isStaff } = useIsStaff(user?.userId ?? "");
+  const { data: isOwner } = useIsOwner(user?.userId ?? "");
+  const usesBarberCalendar = Boolean(isBarber || isStaff || isOwner);
+
+  const { data: unread } = useUnreadNotificationsCount();
+  const { markAllReadMutation } = useNotificationActions();
+
+  const pageBodyProps: PageBodyProps = {
+    cursor,
+    setCursor,
+    cursorStack,
+    setCursorStack,
+    usesBarberCalendar,
+  };
+
+  return (
+    <section className="flex flex-col gap-6">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-1">
+          <h2 className="font-semibold text-foreground text-xl tracking-tight">
+            Notificaciones
+          </h2>
+          <p className="text-muted-foreground text-sm">
+            {unread
+              ? `Tienes ${unread} ${unread === 1 ? "notificación nueva" : "notificaciones nuevas"}.`
+              : "Aquí verás tus actualizaciones en tiempo real."}
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Tabs
+            value={filter}
+            onValueChange={(v) => {
+              setFilter(v as NotificationsFilter);
+              setCursor(null);
+              setCursorStack([]);
+            }}
+            orientation="horizontal"
+          >
+            <TabsList variant="default" className="h-9">
+              <TabsTrigger value="all">Todas</TabsTrigger>
+              <TabsTrigger value="unread" className="gap-1.5">
+                Sin leer
+                {unread ? (
+                  <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1.5 font-medium text-[11px] text-primary-foreground tabular-nums">
+                    {unread === 99 || unread === "99+" ? "99+" : unread}
+                  </span>
+                ) : null}
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={unread === 0 || markAllReadMutation.isPending}
+            onClick={() => markAllReadMutation.mutate({})}
+          >
+            <CheckIcon />
+            Marcar todas como leídas
+          </Button>
+        </div>
+      </header>
+
+      <Suspense key={filter} fallback={<ProfileTabSkeleton />}>
+        {filter === "all" ? (
+          <NotificationsAllPageBody {...pageBodyProps} />
+        ) : (
+          <NotificationsUnreadPageBody {...pageBodyProps} />
+        )}
+      </Suspense>
     </section>
   );
 };

--- a/src/components/profile/notifications-tab.tsx
+++ b/src/components/profile/notifications-tab.tsx
@@ -1,6 +1,7 @@
 import type { InAppNotification } from "@convex/schema";
 import { BellSimpleIcon, CheckIcon, SparkleIcon } from "@phosphor-icons/react";
 import { useMemo, useState } from "react";
+
 import { ProfileTabSkeleton } from "@/components/layout/skeleton/profile-tab-skeleton";
 import { NotificationRenderer } from "@/components/notifications/notification-renderer";
 import { getSectionLabel } from "@/components/notifications/relative-time";
@@ -85,7 +86,7 @@ export const NotificationsTab = () => {
             Notificaciones
           </h2>
           <p className="text-muted-foreground text-sm">
-            {unread > 0
+            {unread
               ? `Tienes ${unread} ${unread === 1 ? "notificación nueva" : "notificaciones nuevas"}.`
               : "Aquí verás tus actualizaciones en tiempo real."}
           </p>
@@ -101,9 +102,9 @@ export const NotificationsTab = () => {
               <TabsTrigger value="all">Todas</TabsTrigger>
               <TabsTrigger value="unread" className="gap-1.5">
                 Sin leer
-                {unread > 0 ? (
+                {unread ? (
                   <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1.5 font-medium text-[11px] text-primary-foreground tabular-nums">
-                    {unread > 99 ? "99+" : unread}
+                    {unread === 99 || unread === "99+" ? "99+" : unread}
                   </span>
                 ) : null}
               </TabsTrigger>

--- a/src/hooks/use-notifications.ts
+++ b/src/hooks/use-notifications.ts
@@ -19,6 +19,15 @@ export function notificationsPageQueryOptions(opts: {
   });
 }
 
+export function unreadNotificationsPageQueryOptions(opts: {
+  cursor: string | null;
+  numItems: number;
+}) {
+  return convexQuery(api.notifications.listUnread, {
+    paginationOpts: opts,
+  });
+}
+
 /** Live-updating list of the 5 most recent notifications for the current user. */
 export function useRecentNotifications() {
   return useQuery(recentNotificationsQueryOptions());
@@ -34,6 +43,13 @@ export function useNotificationsPage(opts: {
   numItems: number;
 }) {
   return useQuery(notificationsPageQueryOptions(opts));
+}
+
+export function useUnreadNotificationsPage(opts: {
+  cursor: string | null;
+  numItems: number;
+}) {
+  return useQuery(unreadNotificationsPageQueryOptions(opts));
 }
 
 export function useNotificationActions() {

--- a/src/hooks/use-notifications.ts
+++ b/src/hooks/use-notifications.ts
@@ -1,6 +1,6 @@
 import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
 import { api } from "@convex/_generated/api";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 
 export function recentNotificationsQueryOptions() {
   return convexQuery(api.notifications.listRecent, {});
@@ -30,26 +30,26 @@ export function unreadNotificationsPageQueryOptions(opts: {
 
 /** Live-updating list of the 5 most recent notifications for the current user. */
 export function useRecentNotifications() {
-  return useQuery(recentNotificationsQueryOptions());
+  return useSuspenseQuery(recentNotificationsQueryOptions());
 }
 
 /** Live-updating count of unread notifications for the header bell. */
 export function useUnreadNotificationsCount() {
-  return useQuery(unreadNotificationsCountQueryOptions());
+  return useSuspenseQuery(unreadNotificationsCountQueryOptions());
 }
 
 export function useNotificationsPage(opts: {
   cursor: string | null;
   numItems: number;
 }) {
-  return useQuery(notificationsPageQueryOptions(opts));
+  return useSuspenseQuery(notificationsPageQueryOptions(opts));
 }
 
 export function useUnreadNotificationsPage(opts: {
   cursor: string | null;
   numItems: number;
 }) {
-  return useQuery(unreadNotificationsPageQueryOptions(opts));
+  return useSuspenseQuery(unreadNotificationsPageQueryOptions(opts));
 }
 
 export function useNotificationActions() {

--- a/src/hooks/use-notifications.ts
+++ b/src/hooks/use-notifications.ts
@@ -1,0 +1,48 @@
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { api } from "@convex/_generated/api";
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+export function recentNotificationsQueryOptions() {
+  return convexQuery(api.notifications.listRecent, {});
+}
+
+export function unreadNotificationsCountQueryOptions() {
+  return convexQuery(api.notifications.unreadCount, {});
+}
+
+export function notificationsPageQueryOptions(opts: {
+  cursor: string | null;
+  numItems: number;
+}) {
+  return convexQuery(api.notifications.list, {
+    paginationOpts: opts,
+  });
+}
+
+/** Live-updating list of the 5 most recent notifications for the current user. */
+export function useRecentNotifications() {
+  return useQuery(recentNotificationsQueryOptions());
+}
+
+/** Live-updating count of unread notifications for the header bell. */
+export function useUnreadNotificationsCount() {
+  return useQuery(unreadNotificationsCountQueryOptions());
+}
+
+export function useNotificationsPage(opts: {
+  cursor: string | null;
+  numItems: number;
+}) {
+  return useQuery(notificationsPageQueryOptions(opts));
+}
+
+export function useNotificationActions() {
+  const markReadMutation = useMutation({
+    mutationFn: useConvexMutation(api.notifications.markRead),
+  });
+  const markAllReadMutation = useMutation({
+    mutationFn: useConvexMutation(api.notifications.markAllRead),
+  });
+
+  return { markReadMutation, markAllReadMutation };
+}

--- a/src/routes/_authedRoutes/profile/index.tsx
+++ b/src/routes/_authedRoutes/profile/index.tsx
@@ -40,6 +40,12 @@ import {
   useIsStaff,
 } from "@/hooks/use-barbershop-members";
 import { profileQueryOptions, useProfile } from "@/hooks/use-profile";
+import {
+  notificationsPageQueryOptions,
+  recentNotificationsQueryOptions,
+  unreadNotificationsCountQueryOptions,
+  unreadNotificationsPageQueryOptions,
+} from "@/hooks/use-notifications";
 import { servicesByIdsQueryOptions } from "@/hooks/use-services";
 import { getSessionQueryOptions, useSession } from "@/hooks/use-session";
 
@@ -169,6 +175,16 @@ export const Route = createFileRoute("/_authedRoutes/profile/")({
         context.queryClient.ensureQueryData(getPricingPlansQueryOptions()),
         context.queryClient.ensureQueryData(getSubscriptionQueryOptions()),
         context.queryClient.ensureQueryData(getExtraCreditsQueryOptions()),
+        context.queryClient.ensureQueryData(
+          unreadNotificationsCountQueryOptions(),
+        ),
+        context.queryClient.ensureQueryData(
+          notificationsPageQueryOptions({ cursor: null, numItems: 20 }),
+        ),
+        context.queryClient.ensureQueryData(
+          unreadNotificationsPageQueryOptions({ cursor: null, numItems: 20 }),
+        ),
+        context.queryClient.ensureQueryData(recentNotificationsQueryOptions()),
       ]);
 
       if (appointments) {

--- a/src/routes/_authedRoutes/profile/index.tsx
+++ b/src/routes/_authedRoutes/profile/index.tsx
@@ -253,7 +253,7 @@ function ProfilePage() {
               <TabsTrigger
                 key={tabOption.value}
                 value={tabOption.value}
-                className="text-sm sm:min-w-max"
+                className="text-xs sm:min-w-max sm:text-sm"
               >
                 {tabOption.label}
               </TabsTrigger>

--- a/src/routes/_authedRoutes/profile/index.tsx
+++ b/src/routes/_authedRoutes/profile/index.tsx
@@ -73,8 +73,14 @@ const SecurityTab = lazy(() =>
     default: mod.SecurityTab,
   })),
 );
+const NotificationsTab = lazy(() =>
+  import("@/components/profile/notifications-tab").then((mod) => ({
+    default: mod.NotificationsTab,
+  })),
+);
 
 type ProfileTabValue =
+  | "notifications"
   | "account"
   | "security"
   | "appointments"
@@ -83,6 +89,10 @@ type ProfileTabValue =
   | "plans";
 
 const tabs = {
+  notifications: {
+    label: "Notificaciones",
+    value: "notifications",
+  },
   account: {
     label: "Perfil",
     value: "account",
@@ -111,6 +121,7 @@ const tabs = {
 
 const searchSchema = z.object({
   tab: z.enum([
+    "notifications",
     "account",
     "security",
     "appointments",
@@ -203,7 +214,9 @@ function ProfilePage() {
   };
 
   const tabsToRender = useMemo(() => {
-    const base = [tabs.account, tabs.security];
+    // Notificaciones sits first so the bell popover lands the user on a familiar
+    // left-most tab, while Perfil stays the default for direct /profile visits.
+    const base = [tabs.notifications, tabs.account, tabs.security];
 
     // Owners (whether or not they're barbers) see Plans and Danger tabs
     if (rolesData?.isOwner) {
@@ -240,12 +253,18 @@ function ProfilePage() {
               <TabsTrigger
                 key={tabOption.value}
                 value={tabOption.value}
-                className="text-sm sm:min-w-24"
+                className="text-sm sm:min-w-max"
               >
                 {tabOption.label}
               </TabsTrigger>
             ))}
           </TabsList>
+
+          <Suspense fallback={<ProfileTabSkeleton />}>
+            <TabsContent value={tabs.notifications.value} className="pt-2">
+              <NotificationsTab />
+            </TabsContent>
+          </Suspense>
 
           <Suspense fallback={<ProfileTabSkeleton />}>
             <TabsContent value={tabs.account.value} className="pt-2">


### PR DESCRIPTION
Add notifications to app

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a complete in-app notification system: a new `inAppNotifications` Convex table with paginated queries, server-side unread filtering, a `markAllRead` batching loop, and a full React component tree (bell popover, profile tab, per-kind variant renderers). The three issues from the previous review round — `unreadCount` cap at 100, `markAllRead` silently leaving notifications unread, and client-side unread filtering — are all resolved.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all previously flagged P1 issues are resolved; the one remaining finding is a minor display inconsistency.

All three P1/P2 issues from the prior review round (unreadCount cap, markAllRead truncation, client-side unread filter) are properly addressed. The only new finding is a P2 badge display edge case when unread count equals exactly 100, which does not affect data correctness or user experience in any meaningful way.

src/components/profile/notifications-tab.tsx (badge display logic on line 311)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| convex/notifications.ts | Core notification mutation/query handlers: adds listRecent, list, listUnread, unreadCount (now 99+), markRead, markAllRead (now loops in batches), and all createX helpers with recordInApp integration. Previously flagged issues around take(200) and the unreadCount cap are resolved. |
| convex/notificationCopy.ts | Single source of truth for notification copy across email, SMS, and in-app channels. Previously flagged typo and barber deep-link are now corrected. BaseInput is unused but inert. |
| convex/schema.ts | Adds inAppNotifications table with by_user_created and by_user_unread (userId + readAt) indexes; notification kind enum is exhaustive and correctly matched throughout the codebase. |
| src/components/profile/notifications-tab.tsx | Profile notifications tab with server-side paginated all/unread views; previously flagged client-side filter bug is now resolved. Minor badge display inconsistency when unread count equals exactly 100. |
| src/components/notifications/notifications-bell.tsx | Header bell popover showing 5 most-recent notifications with unread badge; badge logic (<=9 exact, else "9+") is correct. |
| src/components/notifications/notification-renderer.tsx | Dispatcher component mapping notification kind to the correct variant; exhaustive switch with never-check guards against unhandled kinds. |
| src/components/notifications/notification-item.tsx | Compound component primitive shared by all notification variants; correct keyboard/click handling and density-aware styling. |
| src/hooks/use-notifications.ts | React-Query hooks wrapping Convex live queries; straightforward and correctly structured with Suspense-compatible useSuspenseQuery. |
| convex/notificationSubjects.ts | Centralised email subject/title strings; complete coverage for all notification kinds. |
| src/components/notifications/variants/appointment-notification.tsx | Handles appointment_created, barber_appointment_created, appointment_reminder, past_appointment_reminder kinds; stale date issue from previous review thread (getAppointmentHubLink called at module init in config) remains unfixed. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Client (React)
    participant Convex as Convex Mutation
    participant DB as inAppNotifications
    participant SMS as Twilio
    participant Email as Email Service

    App->>Convex: createAppointmentCreated / createAppointmentCancelled / ...
    Convex->>Convex: buildNotificationCopy(input)
    Convex->>SMS: scheduleSmsWithQuota (if enabled + quota OK)
    Convex->>Email: scheduleEmailWithQuota (if enabled + quota OK)
    Convex->>DB: recordInApp → insert(userId, kind, title, description, payload)

    App->>Convex: listRecent / list / listUnread (queries)
    Convex->>DB: query by_user_created / by_user_unread
    DB-->>Convex: notification rows
    Convex-->>App: paginated results

    App->>Convex: unreadCount
    Convex->>DB: .withIndex("by_user_unread").take(101)
    DB-->>Convex: rows
    Convex-->>App: number (0-100) or "99+"

    App->>Convex: markRead(id)
    Convex->>DB: patch(id, { readAt: now })

    App->>Convex: markAllRead()
    loop while unread batch = 200
        Convex->>DB: .take(200) unread rows
        Convex->>DB: patch each row { readAt: now }
    end
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcomponents%2Fprofile%2Fnotifications-tab.tsx%3A311%0A**Badge%20display%20off-by-one%20on%20exactly%20100%20unread**%0A%0AThe%20condition%20%60unread%20%3D%3D%3D%2099%20%7C%7C%20unread%20%3D%3D%3D%20%2299%2B%22%60%20misses%20the%20case%20where%20the%20server%20returns%20the%20number%20%60100%60.%20Because%20%60unreadCount%60%20does%20%60.take%28101%29%60%20and%20returns%20%60unread.length%20%3E%20100%20%3F%20%2299%2B%22%20%3A%20unread.length%60%2C%20a%20user%20with%20exactly%20100%20unread%20notifications%20gets%20the%20number%20%60100%60%20from%20the%20server.%20That%20value%20falls%20through%20to%20display%20as%20%60%22100%22%60%2C%20not%20%60%2299%2B%22%60.%20Additionally%2C%20%60unread%20%3D%3D%3D%2099%60%20maps%2099%20unread%20to%20%60%2299%2B%22%60%2C%20hiding%20an%20exact%20count%20that%20is%20still%20meaningful.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bunread%20%3D%3D%3D%20%2299%2B%22%20%7C%7C%20%28typeof%20unread%20%3D%3D%3D%20%22number%22%20%26%26%20unread%20%3E%2099%29%20%3F%20%2299%2B%22%20%3A%20unread%7D%0A%60%60%60%0A%0A&pr=76&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcomponents%2Fprofile%2Fnotifications-tab.tsx%3A311%0A**Badge%20display%20off-by-one%20on%20exactly%20100%20unread**%0A%0AThe%20condition%20%60unread%20%3D%3D%3D%2099%20%7C%7C%20unread%20%3D%3D%3D%20%2299%2B%22%60%20misses%20the%20case%20where%20the%20server%20returns%20the%20number%20%60100%60.%20Because%20%60unreadCount%60%20does%20%60.take%28101%29%60%20and%20returns%20%60unread.length%20%3E%20100%20%3F%20%2299%2B%22%20%3A%20unread.length%60%2C%20a%20user%20with%20exactly%20100%20unread%20notifications%20gets%20the%20number%20%60100%60%20from%20the%20server.%20That%20value%20falls%20through%20to%20display%20as%20%60%22100%22%60%2C%20not%20%60%2299%2B%22%60.%20Additionally%2C%20%60unread%20%3D%3D%3D%2099%60%20maps%2099%20unread%20to%20%60%2299%2B%22%60%2C%20hiding%20an%20exact%20count%20that%20is%20still%20meaningful.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7Bunread%20%3D%3D%3D%20%2299%2B%22%20%7C%7C%20%28typeof%20unread%20%3D%3D%3D%20%22number%22%20%26%26%20unread%20%3E%2099%29%20%3F%20%2299%2B%22%20%3A%20unread%7D%0A%60%60%60%0A%0A&repo=pulgueta%2Fpanabarbero&pr=76&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["refactor(notifications): update appointm..."](https://github.com/pulgueta/panabarbero/commit/62a802a09b1b64b71b0019d34279c49d413cb10a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28938223)</sub>

<!-- /greptile_comment -->