### PR TITLE
feat(billing): add Mercado Pago free trials

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -193,7 +193,7 @@ without an account/membership. Acquisition:
 
 | Role | How acquired | Gating |
 |---|---|---|
-| **owner** | Creating a barbershop (`barbershops.create`) inserts an `["owner", ...]` member. Requires an **active billing entitlement** (`assertIsSubscribed`). Paid Mercado Pago plans grant access only after an approved payment; the free plan is local. | `ownerIsBarber` decides whether `"barber"` is also added, i.e. whether the owner attends clients. |
+| **owner** | Creating a barbershop (`barbershops.create`) inserts an `["owner", ...]` member. Requires an **active billing entitlement** (`assertIsSubscribed`). Paid Mercado Pago plans grant access during a provider-confirmed free trial or after an approved payment; the free plan is local. | `ownerIsBarber` decides whether `"barber"` is also added, i.e. whether the owner attends clients. |
 | **barber** | Accepting an invitation whose metadata role is `barber`. | — |
 | **staff** (recepcionista) | Accepting an invitation whose role is `staff`. | Inviting staff requires the owner's plan to allow it (`assertStaffInviteAllowed` — pro/premium only; free plan rejects with "límite de personal"). |
 | **customer** | Plain signup. No membership row. | Booking needs name + phone; email optional. |

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -45,6 +45,7 @@ import type * as mercadopago from "../mercadopago.js";
 import type * as mercadopagoCheckoutAttempts from "../mercadopagoCheckoutAttempts.js";
 import type * as mercadopagoPaymentState from "../mercadopagoPaymentState.js";
 import type * as mercadopagoPlans from "../mercadopagoPlans.js";
+import type * as mercadopagoSubscriptionState from "../mercadopagoSubscriptionState.js";
 import type * as mercadopagoSubscriptions from "../mercadopagoSubscriptions.js";
 import type * as mercadopagoWebhookSignature from "../mercadopagoWebhookSignature.js";
 import type * as mercadopagoWebhooks from "../mercadopagoWebhooks.js";
@@ -109,6 +110,7 @@ declare const fullApi: ApiFromModules<{
   mercadopagoCheckoutAttempts: typeof mercadopagoCheckoutAttempts;
   mercadopagoPaymentState: typeof mercadopagoPaymentState;
   mercadopagoPlans: typeof mercadopagoPlans;
+  mercadopagoSubscriptionState: typeof mercadopagoSubscriptionState;
   mercadopagoSubscriptions: typeof mercadopagoSubscriptions;
   mercadopagoWebhookSignature: typeof mercadopagoWebhookSignature;
   mercadopagoWebhooks: typeof mercadopagoWebhooks;

--- a/convex/mercadopago.ts
+++ b/convex/mercadopago.ts
@@ -22,6 +22,10 @@ import {
   MP_FREE_PRODUCT_KEY,
   MP_PAID_PRODUCT_KEYS,
 } from "./mercadopagoPlans";
+import {
+  isExpectedFreeTrial,
+  MP_FREE_TRIAL_DAYS,
+} from "./mercadopagoSubscriptionState";
 import { processAuthorizedPayment } from "./mercadopagoWebhooks";
 import { siteUrl } from "./notificationCopy";
 import { CREDIT_PRODUCT_KEYS } from "./plans";
@@ -116,7 +120,8 @@ function assertPreapprovalMatchesCheckout(
     amount !== plan.amountCop ||
     recurring?.currency_id !== MP_CURRENCY_ID ||
     recurring?.frequency !== plan.frequency ||
-    recurring?.frequency_type !== plan.frequencyType
+    recurring?.frequency_type !== plan.frequencyType ||
+    !isExpectedFreeTrial(recurring?.free_trial)
   ) {
     throw new ConvexError(
       "La suscripción de Mercado Pago no coincide con el checkout creado por PanaBarbero.",
@@ -134,6 +139,16 @@ async function materializeSubscriptionCheckout(
   }
 
   const plan = getMpPlan(attempt.productKey);
+  const autoRecurring = {
+    frequency: plan.frequency,
+    frequency_type: plan.frequencyType,
+    transaction_amount: plan.amountCop,
+    currency_id: MP_CURRENCY_ID,
+    free_trial: {
+      frequency: MP_FREE_TRIAL_DAYS,
+      frequency_type: "days",
+    },
+  };
   const subscription = await new PreApproval(mpConfig()).create({
     body: {
       reason: plan.reason,
@@ -141,12 +156,7 @@ async function materializeSubscriptionCheckout(
       payer_email: attempt.payerEmail,
       back_url: `${siteUrl()}/profile?tab=plans&subscription=success`,
       status: "pending",
-      auto_recurring: {
-        frequency: plan.frequency,
-        frequency_type: plan.frequencyType,
-        transaction_amount: plan.amountCop,
-        currency_id: MP_CURRENCY_ID,
-      },
+      auto_recurring: autoRecurring,
     },
     requestOptions: { idempotencyKey: attempt.idempotencyKey },
   });
@@ -169,6 +179,7 @@ async function materializeSubscriptionCheckout(
     currencyId: MP_CURRENCY_ID,
     initPoint: subscription.init_point,
     nextPaymentDate: subscription.next_payment_date,
+    trialDays: MP_FREE_TRIAL_DAYS,
     remoteUpdatedAt: remoteTimestamp(subscription.last_modified),
   });
 

--- a/convex/mercadopagoCheckoutAttempts.ts
+++ b/convex/mercadopagoCheckoutAttempts.ts
@@ -120,6 +120,7 @@ export const complete = zInternalMutation({
     currencyId: z.string(),
     initPoint: z.string(),
     nextPaymentDate: z.string().optional(),
+    trialDays: z.number().int().positive(),
     remoteUpdatedAt: z.number().optional(),
   }),
   handler: async (ctx, args) => {
@@ -155,6 +156,7 @@ export const complete = zInternalMutation({
       initPoint: args.initPoint,
       externalReference: attempt.checkoutReference,
       nextPaymentDate: args.nextPaymentDate,
+      trialDays: args.trialDays,
       remoteUpdatedAt: args.remoteUpdatedAt,
       updatedAt: now,
     } as const;

--- a/convex/mercadopagoSubscriptionState.ts
+++ b/convex/mercadopagoSubscriptionState.ts
@@ -1,0 +1,52 @@
+/** Pure Mercado Pago subscription-trial and entitlement helpers. */
+
+export const MP_FREE_TRIAL_DAYS = 14;
+
+export function isExpectedFreeTrial(value: unknown) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const trial = value as Record<string, unknown>;
+  return (
+    trial.frequency === MP_FREE_TRIAL_DAYS && trial.frequency_type === "days"
+  );
+}
+
+export function initialTrialEndsAt({
+  existingTrialEndsAt,
+  mpStatus,
+  nextPaymentDate,
+  trialDays,
+}: {
+  existingTrialEndsAt?: number;
+  mpStatus: string;
+  nextPaymentDate?: string;
+  trialDays?: number;
+}) {
+  if (
+    existingTrialEndsAt !== undefined ||
+    mpStatus !== "authorized" ||
+    trialDays === undefined ||
+    nextPaymentDate === undefined
+  ) {
+    return existingTrialEndsAt;
+  }
+
+  const parsed = Date.parse(nextPaymentDate);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function hasActivePaidEntitlement(
+  row: {
+    status: string;
+    paidThrough?: number;
+    trialEndsAt?: number;
+  },
+  now: number,
+) {
+  return (
+    row.status === "active" &&
+    ((row.paidThrough ?? 0) > now || (row.trialEndsAt ?? 0) > now)
+  );
+}

--- a/convex/mercadopagoSubscriptions.ts
+++ b/convex/mercadopagoSubscriptions.ts
@@ -1,4 +1,4 @@
-/** MercadoPago subscription persistence and payment-backed entitlement logic. */
+/** MercadoPago subscription persistence and paid-plan entitlement logic. */
 
 import { ConvexError } from "convex/values";
 import { z } from "zod";
@@ -17,6 +17,10 @@ import {
   type MpSubscriptionStatus,
   normalizeMpStatus,
 } from "./mercadopagoPlans";
+import {
+  hasActivePaidEntitlement,
+  initialTrialEndsAt,
+} from "./mercadopagoSubscriptionState";
 import { getLimitsForProductKey, getTierForProductKey } from "./plans";
 import type { MercadopagoSubscription } from "./schema";
 
@@ -88,15 +92,11 @@ function pickDisplayRow(
 }
 
 function hasEntitlement(row: MercadopagoSubscription, now: number) {
-  if (row.status !== "active") {
-    return false;
-  }
-
   if (!row.preapprovalId) {
-    return row.productKey === MP_FREE_PRODUCT_KEY;
+    return row.status === "active" && row.productKey === MP_FREE_PRODUCT_KEY;
   }
 
-  return (row.paidThrough ?? 0) > now;
+  return hasActivePaidEntitlement(row, now);
 }
 
 function pickEntitlementRow(
@@ -284,6 +284,13 @@ export const applyPreapprovalState = zInternalMutation({
       return false;
     }
 
+    const trialEndsAt = initialTrialEndsAt({
+      existingTrialEndsAt: existing.trialEndsAt,
+      mpStatus: args.mpStatus,
+      nextPaymentDate: args.nextPaymentDate,
+      trialDays: existing.trialDays,
+    });
+
     await ctx.db.patch(existing._id, {
       status,
       mpStatus: args.mpStatus,
@@ -292,6 +299,7 @@ export const applyPreapprovalState = zInternalMutation({
       ...(args.nextPaymentDate !== undefined && {
         nextPaymentDate: args.nextPaymentDate,
       }),
+      ...(trialEndsAt !== undefined && { trialEndsAt }),
       ...(args.remoteUpdatedAt !== undefined && {
         remoteUpdatedAt: args.remoteUpdatedAt,
       }),
@@ -308,6 +316,16 @@ export const applyPreapprovalState = zInternalMutation({
       if (attempt) {
         await ctx.db.delete(attempt._id);
       }
+    } else if (
+      existing.trialEndsAt === undefined &&
+      trialEndsAt !== undefined &&
+      trialEndsAt > Date.now()
+    ) {
+      await ctx.scheduler.runAt(
+        trialEndsAt,
+        internal.mercadopagoSubscriptions.refreshTrialEntitlement,
+        { preapprovalId: args.preapprovalId, trialEndsAt },
+      );
     }
 
     return true;
@@ -450,6 +468,27 @@ export const refreshEntitlement = zInternalMutation({
     if (
       row?.paidThrough === args.paidThrough &&
       row.paidThrough <= Date.now()
+    ) {
+      await ctx.db.patch(row._id, { updatedAt: Date.now() });
+    }
+  },
+});
+
+/** Trigger reactive clients if the first charge is delayed past trial expiry. */
+export const refreshTrialEntitlement = zInternalMutation({
+  args: z.object({ preapprovalId: z.string(), trialEndsAt: z.number() }),
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("mercadopagoSubscriptions")
+      .withIndex("by_preapprovalId", (q) =>
+        q.eq("preapprovalId", args.preapprovalId),
+      )
+      .unique();
+
+    if (
+      row?.trialEndsAt === args.trialEndsAt &&
+      row.trialEndsAt <= Date.now() &&
+      (row.paidThrough ?? 0) <= Date.now()
     ) {
       await ctx.db.patch(row._id, { updatedAt: Date.now() });
     }

--- a/convex/mercadopagoWebhooks.ts
+++ b/convex/mercadopagoWebhooks.ts
@@ -25,6 +25,7 @@ import {
   isMpPaidProductKey,
   MP_CURRENCY_ID,
 } from "./mercadopagoPlans";
+import { isExpectedFreeTrial } from "./mercadopagoSubscriptionState";
 import { isWebhookTimestampWithinTolerance } from "./mercadopagoWebhookSignature";
 
 type InvoiceResponse = Awaited<ReturnType<Invoice["get"]>>;
@@ -36,6 +37,7 @@ interface StoredSubscription {
   productKey: string;
   externalReference?: string;
   lastInvoiceId?: string;
+  trialDays?: number;
 }
 
 interface PaymentOverride {
@@ -77,7 +79,9 @@ function validateRemoteSubscription(
     Number(recurring?.transaction_amount) === plan.amountCop &&
     recurring?.currency_id === MP_CURRENCY_ID &&
     recurring?.frequency === plan.frequency &&
-    recurring?.frequency_type === plan.frequencyType
+    recurring?.frequency_type === plan.frequencyType &&
+    (stored.trialDays === undefined ||
+      isExpectedFreeTrial(recurring?.free_trial))
   );
 }
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -536,7 +536,7 @@ export const mercadopagoSubscriptions = zodTable(
     userId: z.string(),
     /** Shared vocabulary with `convex/plans.ts` — drives the plan tier. */
     productKey: z.string(),
-    /** App-normalized agreement status. Paid access also requires `paidThrough`. */
+    /** App-normalized agreement status. Paid access requires payment or trial time. */
     status: z.enum(["active", "pending", "paused", "canceled"]),
     /** Raw MercadoPago preapproval status (authorized/pending/paused/cancelled). */
     mpStatus: z.string().optional(),
@@ -553,9 +553,13 @@ export const mercadopagoSubscriptions = zodTable(
     externalReference: z.string().optional(),
     /** ISO date of the next scheduled charge, when known. */
     nextPaymentDate: z.string().optional(),
+    /** Free-trial duration configured when this agreement was created. */
+    trialDays: z.number().int().positive().optional(),
+    /** Provider-confirmed first charge timestamp that ends the free trial. */
+    trialEndsAt: z.number().optional(),
     /** Latest MercadoPago `last_modified` applied to the agreement. */
     remoteUpdatedAt: z.number().optional(),
-    /** Paid access remains valid through this timestamp while status is active. */
+    /** Paid access remains valid through this timestamp after a successful charge. */
     paidThrough: z.number().optional(),
     lastInvoiceId: z.string().optional(),
     lastPaymentId: z.string().optional(),

--- a/docs/mercadopago-subscriptions.md
+++ b/docs/mercadopago-subscriptions.md
@@ -1,6 +1,6 @@
 # Mercado Pago billing architecture
 
-PanaBarbero uses Mercado Pago for recurring paid plans and one-time SMS or email credit packs. Convex owns checkout identity, authorization, plan limits, and entitlement state; a redirect or an authorized preapproval never grants access by itself.
+PanaBarbero uses Mercado Pago for recurring paid plans and one-time SMS or email credit packs. Convex owns checkout identity, authorization, plan limits, and entitlement state; a redirect never grants access by itself.
 
 Market: Colombia (`MCO`). Currency: Colombian pesos (`COP`). User-facing copy: Spanish (`es-CO`).
 
@@ -12,7 +12,7 @@ Each billing layer has one responsibility:
 | --- | --- | --- |
 | Catalog | `convex/plans.ts`, `convex/mercadopagoPlans.ts` | Stable product keys, prices, intervals, credit packs, and plan limits |
 | Subscription checkout | `convex/mercadopago.ts`, `convex/mercadopagoCheckoutAttempts.ts` | Durable checkout claim, hosted checkout creation, reconciliation, cancellation, and free-plan activation |
-| Subscription entitlement | `convex/mercadopagoSubscriptions.ts` | Agreement state, approved payment periods, bounded reads, and the client-safe subscription result |
+| Subscription entitlement | `convex/mercadopagoSubscriptions.ts` | Agreement state, free-trial and approved-payment periods, bounded reads, and the client-safe subscription result |
 | Credit checkout | `convex/mercadopago.ts`, `convex/credits.ts` | Server-owned credit intent, Checkout Pro preference, grants, refunds, and chargebacks |
 | Webhooks | `convex/http.ts`, `convex/mercadopagoWebhooks.ts` | Signature validation, remote resource fetches, catalog validation, and ordered state transitions |
 | Client | `src/hooks/billing/use-mercadopago.ts`, `src/components/pricing/` | Pricing, redirect, pending state, cancellation confirmation, and plan management |
@@ -45,26 +45,26 @@ The checkout action serializes creation per user and reuses one stable idempoten
 2. `mercadopagoCheckoutAttempts.acquire` atomically creates or resumes the per-user checkout claim.
 3. The action fetches every locally open preapproval from Mercado Pago. An unreachable or unverified remote state blocks checkout.
 4. The action cancels only remote preapprovals confirmed as abandoned and `pending`. Any live agreement blocks a second checkout.
-5. `PreApproval.create` receives the server-owned reference, catalog amount, interval, currency, and the claim's stable idempotency key.
+5. `PreApproval.create` receives the server-owned reference, catalog amount, interval, currency, 14-day free trial, and the claim's stable idempotency key.
 6. The completion mutation stores the preapproval and reusable hosted checkout URL in the same transaction.
-7. The browser redirects to Mercado Pago. Returning to PanaBarbero shows a pending state until a payment webhook proves access.
+7. The browser redirects to Mercado Pago. Returning to PanaBarbero shows a pending state until Mercado Pago authorizes the trial or an approved payment proves access.
 
 Concurrent requests cannot create independent claims for the same user. Convex transaction conflicts serialize the indexed read and insert, while Mercado Pago deduplicates retries with the persisted idempotency key.
 
 ## Paid entitlement lifecycle
 
-Agreement state and paid access are separate. A `subscription_preapproval` event may mark the agreement `authorized`, but it does not grant a paid plan.
+Agreement state and paid access are separate. A `subscription_preapproval` event may mark the agreement `authorized`; it grants trial access only when the local checkout configured a free trial and Mercado Pago confirms a future first charge date.
 
 Paid access requires both conditions:
 
 - The normalized agreement status is `active`
-- `paidThrough` is later than the current server time
+- `trialEndsAt` or `paidThrough` is later than the current server time
 
-Only a financially entitling authorized-payment invoice extends `paidThrough`. Approved and partially refunded payments keep the paid period; rejected or pending payments do not extend it. A full refund or unresolved chargeback against the payment that granted the current period revokes access, while a reimbursed chargeback restores it. The scheduled expiry mutation refreshes reactive clients when an unpaid period ends.
+The first provider-confirmed `next_payment_date` fixes `trialEndsAt`; later agreement updates cannot extend it. Only a financially entitling authorized-payment invoice extends `paidThrough`. Approved and partially refunded payments keep the paid period; rejected or pending payments do not extend it. A full refund or unresolved chargeback against the payment that granted the current period revokes access, while a reimbursed chargeback restores it. Scheduled expiry mutations refresh reactive clients when a trial or unpaid period ends.
 
-If a payment webhook is missed, the user can request reconciliation from the pricing card. The action fetches the authorized-payment page by preapproval, replays it oldest-first through the same validated idempotent recorder used by webhooks, and never grants access from agreement authorization alone.
+If a payment webhook is missed, the user can request reconciliation from the pricing card. The action fetches the authorized-payment page by preapproval and replays it oldest-first through the same validated idempotent recorder used by webhooks. Agreement authorization grants access only for a locally configured, provider-confirmed trial.
 
-Webhook reconciliation validates the stored preapproval id, checkout reference, product key, amount, currency, frequency, and frequency type against the server catalog. Remote timestamps prevent older events from overwriting newer agreement or payment state.
+Webhook reconciliation validates the stored preapproval id, checkout reference, product key, amount, currency, frequency, frequency type, and free-trial configuration against the server catalog. Remote timestamps prevent older events from overwriting newer agreement or payment state.
 
 See Mercado Pago's [authorized payment lifecycle](https://www.mercadopago.com.co/developers/en/docs/subscriptions/integration-configuration/subscription-no-associated-plan/authorized-payments) for the provider-side payment model.
 

--- a/tests/mercadopago-payment-state.test.ts
+++ b/tests/mercadopago-payment-state.test.ts
@@ -6,6 +6,12 @@ import {
   classifyPaymentState,
 } from "../convex/mercadopagoPaymentState.ts";
 import { isWebhookTimestampWithinTolerance } from "../convex/mercadopagoWebhookSignature.ts";
+import {
+  hasActivePaidEntitlement,
+  initialTrialEndsAt,
+  isExpectedFreeTrial,
+  MP_FREE_TRIAL_DAYS,
+} from "../convex/mercadopagoSubscriptionState.ts";
 
 const baseCreditState = {
   credits: 1000,
@@ -237,4 +243,65 @@ test("partially refunded subscription payments remain financially entitling", ()
   assert.equal(state.canonicalStatus, "partially_refunded");
   assert.equal(state.entitling, true);
   assert.equal(state.reversed, false);
+});
+
+test("the configured Mercado Pago trial is 14 days", () => {
+  assert.equal(
+    isExpectedFreeTrial({
+      frequency: MP_FREE_TRIAL_DAYS,
+      frequency_type: "days",
+    }),
+    true,
+  );
+  assert.equal(
+    isExpectedFreeTrial({ frequency: 7, frequency_type: "days" }),
+    false,
+  );
+});
+
+test("an authorized trial grants paid access until the first charge", () => {
+  const now = Date.parse("2026-07-10T12:00:00.000Z");
+  const nextPaymentDate = "2026-07-24T12:00:00.000Z";
+  const trialEndsAt = initialTrialEndsAt({
+    mpStatus: "authorized",
+    nextPaymentDate,
+    trialDays: MP_FREE_TRIAL_DAYS,
+  });
+
+  assert.equal(trialEndsAt, Date.parse(nextPaymentDate));
+  assert.equal(
+    hasActivePaidEntitlement({ status: "active", trialEndsAt }, now),
+    true,
+  );
+  assert.equal(
+    hasActivePaidEntitlement(
+      { status: "active", trialEndsAt },
+      Date.parse(nextPaymentDate) + 1,
+    ),
+    false,
+  );
+  assert.equal(
+    initialTrialEndsAt({
+      existingTrialEndsAt: trialEndsAt,
+      mpStatus: "authorized",
+      nextPaymentDate: "2026-07-25T12:00:00.000Z",
+      trialDays: MP_FREE_TRIAL_DAYS,
+    }),
+    trialEndsAt,
+  );
+});
+
+test("cancellation revokes trial access immediately", () => {
+  const now = Date.parse("2026-07-10T12:00:00.000Z");
+
+  assert.equal(
+    hasActivePaidEntitlement(
+      {
+        status: "canceled",
+        trialEndsAt: now + MP_FREE_TRIAL_DAYS * 24 * 60 * 60 * 1000,
+      },
+      now,
+    ),
+    false,
+  );
 });


### PR DESCRIPTION
## What changed

- configure a 14-day Mercado Pago free trial through the documented `auto_recurring.free_trial` preapproval field
- grant the selected paid-plan entitlement while Mercado Pago reports an authorized agreement before the provider-confirmed first charge date
- preserve payment-backed access after the trial and revoke benefits immediately when the agreement is canceled
- validate the remote trial configuration during checkout and webhook reconciliation
- document and test trial activation, expiry, non-extension, and cancellation behavior

## Why

Paid subscriptions previously required an approved invoice before unlocking paid features, so simply deferring the first charge would have left trial users on the free tier. The entitlement resolver now recognizes only locally configured, provider-confirmed trials while keeping existing subscriptions payment-backed.

## Verification

- `pnpm test:billing` (15 passing)
- `pnpx convex codegen`
- `pnpm exec tsc --noEmit`
- scoped Biome check
- `pnpm doctor:diff` (100/100)
- `pnpm build`
- authenticated browser smoke test: Planes tab renders the current paid plan and cancellation controls; paid appointments dashboard remains accessible with no browser errors

Mercado Pago hosted checkout was not automated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a 14-day Mercado Pago free trial for eligible paid plans.
  * Paid access now remains active through the provider-confirmed trial period or approved payment period.
  * Trial access automatically expires when the trial ends or the subscription is canceled.

* **Bug Fixes**
  * Improved validation of subscription and free-trial details received from Mercado Pago.

* **Documentation**
  * Clarified subscription access, trial behavior, payment states, refunds, and webhook reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->