### PR TITLE
fix(billing): harden free trial entitlement

### DIFF
--- a/convex/mercadopago.ts
+++ b/convex/mercadopago.ts
@@ -3,12 +3,7 @@
 /** MercadoPago checkout, cancellation, and account-deletion network actions. */
 
 import { ConvexError } from "convex/values";
-import {
-  Invoice,
-  MercadoPagoConfig,
-  PreApproval,
-  Preference,
-} from "mercadopago";
+import { MercadoPagoConfig, PreApproval, Preference } from "mercadopago";
 import { z } from "zod";
 
 import { zAuthAction, zInternalAction } from ".";
@@ -23,10 +18,12 @@ import {
   MP_PAID_PRODUCT_KEYS,
 } from "./mercadopagoPlans";
 import {
+  getFreeTrialDays,
+  hasRemoteBillingActivity,
   isExpectedFreeTrial,
-  MP_FREE_TRIAL_DAYS,
+  shouldBlockTrialActivation,
 } from "./mercadopagoSubscriptionState";
-import { processAuthorizedPayment } from "./mercadopagoWebhooks";
+import { reconcileSubscriptionInvoices } from "./mercadopagoWebhooks";
 import { siteUrl } from "./notificationCopy";
 import { CREDIT_PRODUCT_KEYS } from "./plans";
 
@@ -43,6 +40,10 @@ interface RemotePreapprovalState {
   reason?: string;
   next_payment_date?: string | number;
   last_modified?: string | number;
+  summarized?: {
+    charged_quantity?: number | null;
+    last_charged_date?: string | null;
+  };
 }
 
 interface OpenPaidRow {
@@ -60,6 +61,7 @@ interface CheckoutAttempt {
   idempotencyKey: string;
   state: "creating" | "ready";
   leaseExpiresAt: number;
+  trialDays?: number | null;
   preapprovalId?: string;
   initPoint?: string;
 }
@@ -106,6 +108,7 @@ function isTerminalStatus(status: string | undefined) {
 function assertPreapprovalMatchesCheckout(
   subscription: PreapprovalResponse,
   checkout: Pick<CheckoutAttempt, "checkoutReference" | "productKey">,
+  trialDays: number | null,
 ) {
   if (!isMpPaidProductKey(checkout.productKey)) {
     throw new ConvexError("El checkout contiene un plan desconocido.");
@@ -121,12 +124,21 @@ function assertPreapprovalMatchesCheckout(
     recurring?.currency_id !== MP_CURRENCY_ID ||
     recurring?.frequency !== plan.frequency ||
     recurring?.frequency_type !== plan.frequencyType ||
-    !isExpectedFreeTrial(recurring?.free_trial)
+    !isExpectedFreeTrial(recurring?.free_trial, trialDays)
   ) {
     throw new ConvexError(
       "La suscripción de Mercado Pago no coincide con el checkout creado por PanaBarbero.",
     );
   }
+}
+
+function expectedTrialDays(
+  subscription: PreapprovalResponse,
+  attempt: CheckoutAttempt,
+) {
+  return attempt.trialDays === undefined
+    ? (getFreeTrialDays(subscription.auto_recurring?.free_trial) ?? null)
+    : attempt.trialDays;
 }
 
 /** Create or recover one remote checkout from its durable immutable claim. */
@@ -144,10 +156,12 @@ async function materializeSubscriptionCheckout(
     frequency_type: plan.frequencyType,
     transaction_amount: plan.amountCop,
     currency_id: MP_CURRENCY_ID,
-    free_trial: {
-      frequency: MP_FREE_TRIAL_DAYS,
-      frequency_type: "days",
-    },
+    ...(typeof attempt.trialDays === "number" && {
+      free_trial: {
+        frequency: attempt.trialDays,
+        frequency_type: "days",
+      },
+    }),
   };
   const subscription = await new PreApproval(mpConfig()).create({
     body: {
@@ -167,7 +181,8 @@ async function materializeSubscriptionCheckout(
     );
   }
 
-  assertPreapprovalMatchesCheckout(subscription, attempt);
+  const trialDays = expectedTrialDays(subscription, attempt);
+  assertPreapprovalMatchesCheckout(subscription, attempt, trialDays);
 
   await ctx.runMutation(internal.mercadopagoCheckoutAttempts.complete, {
     checkoutReference: attempt.checkoutReference,
@@ -179,7 +194,7 @@ async function materializeSubscriptionCheckout(
     currencyId: MP_CURRENCY_ID,
     initPoint: subscription.init_point,
     nextPaymentDate: subscription.next_payment_date,
-    trialDays: MP_FREE_TRIAL_DAYS,
+    trialDays,
     remoteUpdatedAt: remoteTimestamp(subscription.last_modified),
   });
 
@@ -193,6 +208,7 @@ async function applyRemotePreapproval(
   ctx: ActionCtx,
   preapprovalId: string,
   subscription: RemotePreapprovalState,
+  blockTrialActivation = subscription.status === "authorized",
 ) {
   await ctx.runMutation(
     internal.mercadopagoSubscriptions.applyPreapprovalState,
@@ -206,43 +222,11 @@ async function applyRemotePreapproval(
           ? String(subscription.next_payment_date)
           : undefined,
       remoteUpdatedAt: remoteTimestamp(subscription.last_modified),
+      hasBillingActivity:
+        blockTrialActivation ||
+        hasRemoteBillingActivity(subscription.summarized),
     },
   );
-}
-
-/**
- * Payment-backed entitlement is written by webhooks, which are at-least-once:
- * an authorized agreement whose invoices were never recorded (missed
- * delivery, or activity predating payment-backed entitlement) would keep a
- * paying subscriber on the free tier. Replay the bounded API page oldest-first
- * through the same validated, per-payment idempotent path the webhook uses.
- */
-async function backfillEntitlementFromInvoices(
-  ctx: ActionCtx,
-  preapprovalId: string,
-) {
-  try {
-    const found = await new Invoice(mpConfig()).search({
-      options: { preapproval_id: preapprovalId },
-    });
-
-    const invoices = [...(found.results ?? [])].sort(
-      (a, b) =>
-        remoteTimestamp(a.last_modified ?? a.date_created, 0) -
-        remoteTimestamp(b.last_modified ?? b.date_created, 0),
-    );
-    for (const invoice of invoices) {
-      await processAuthorizedPayment(ctx, invoice);
-    }
-
-    return invoices.length > 0 ? "processed" : "empty";
-  } catch (error) {
-    console.error(
-      `[mercadopago] no se pudieron consultar las facturas de ${preapprovalId}`,
-      error,
-    );
-    return "failed";
-  }
 }
 
 /**
@@ -278,9 +262,8 @@ async function reconcileOpenPaidRows(ctx: ActionCtx, userId: string) {
       continue;
     }
 
-    await applyRemotePreapproval(ctx, row.preapprovalId, remote);
-
     if (remote.status === "pending") {
+      await applyRemotePreapproval(ctx, row.preapprovalId, remote);
       abandonedPending.push(row);
     } else if (!isTerminalStatus(remote.status)) {
       hasLiveSubscription = true;
@@ -289,10 +272,22 @@ async function reconcileOpenPaidRows(ctx: ActionCtx, userId: string) {
         remote.status === "authorized" &&
         (row.paidThrough ?? 0) <= Date.now()
       ) {
-        reconciliationFailed =
-          (await backfillEntitlementFromInvoices(ctx, row.preapprovalId)) ===
-            "failed" || reconciliationFailed;
+        const backfill = await reconcileSubscriptionInvoices(
+          ctx,
+          row.preapprovalId,
+        );
+        reconciliationFailed = backfill === "failed" || reconciliationFailed;
+        await applyRemotePreapproval(
+          ctx,
+          row.preapprovalId,
+          remote,
+          shouldBlockTrialActivation(remote.summarized, backfill),
+        );
+      } else {
+        await applyRemotePreapproval(ctx, row.preapprovalId, remote);
       }
+    } else {
+      await applyRemotePreapproval(ctx, row.preapprovalId, remote);
     }
   }
 
@@ -374,8 +369,18 @@ async function resolveReadyAttempt(
     );
   }
 
-  assertPreapprovalMatchesCheckout(remote, attempt);
-  await applyRemotePreapproval(ctx, attempt.preapprovalId, remote);
+  const trialDays = expectedTrialDays(remote, attempt);
+  assertPreapprovalMatchesCheckout(remote, attempt, trialDays);
+  const invoiceReconciliation =
+    remote.status === "authorized" && trialDays !== null
+      ? await reconcileSubscriptionInvoices(ctx, attempt.preapprovalId)
+      : undefined;
+  await applyRemotePreapproval(
+    ctx,
+    attempt.preapprovalId,
+    remote,
+    shouldBlockTrialActivation(remote.summarized, invoiceReconciliation),
+  );
 
   if (remote.status === "pending") {
     if (

--- a/convex/mercadopagoCheckoutAttempts.ts
+++ b/convex/mercadopagoCheckoutAttempts.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { zInternalMutation, zInternalQuery } from ".";
 import { normalizeMpStatus } from "./mercadopagoPlans";
+import { trialDaysForCheckout } from "./mercadopagoSubscriptionState";
 
 const CHECKOUT_LEASE_MS = 5 * 60 * 1000;
 
@@ -61,8 +62,17 @@ export const acquire = zInternalMutation({
       };
     }
 
+    const consumedTrial = await ctx.db
+      .query("mercadopagoSubscriptions")
+      .withIndex("by_userId_and_trialEndsAt", (q) =>
+        q.eq("userId", args.userId).gt("trialEndsAt", 0),
+      )
+      .first();
+    const trialDays = trialDaysForCheckout(consumedTrial !== null);
+
     const id = await ctx.db.insert("mercadopagoCheckoutAttempts", {
       ...args,
+      trialDays,
       state: "creating",
       leaseExpiresAt: now + CHECKOUT_LEASE_MS,
       createdAt: now,
@@ -75,6 +85,7 @@ export const acquire = zInternalMutation({
       payerEmail: args.payerEmail,
       checkoutReference: args.checkoutReference,
       idempotencyKey: args.idempotencyKey,
+      trialDays,
       state: "creating" as const,
       leaseExpiresAt: now + CHECKOUT_LEASE_MS,
       createdAt: now,
@@ -120,7 +131,7 @@ export const complete = zInternalMutation({
     currencyId: z.string(),
     initPoint: z.string(),
     nextPaymentDate: z.string().optional(),
-    trialDays: z.number().int().positive(),
+    trialDays: z.number().int().positive().nullable(),
     remoteUpdatedAt: z.number().optional(),
   }),
   handler: async (ctx, args) => {
@@ -156,7 +167,7 @@ export const complete = zInternalMutation({
       initPoint: args.initPoint,
       externalReference: attempt.checkoutReference,
       nextPaymentDate: args.nextPaymentDate,
-      trialDays: args.trialDays,
+      trialDays: args.trialDays ?? undefined,
       remoteUpdatedAt: args.remoteUpdatedAt,
       updatedAt: now,
     } as const;
@@ -179,6 +190,7 @@ export const complete = zInternalMutation({
       state: "ready",
       preapprovalId: args.preapprovalId,
       initPoint: args.initPoint,
+      trialDays: args.trialDays,
       leaseExpiresAt: now,
       updatedAt: now,
     });

--- a/convex/mercadopagoSubscriptionState.ts
+++ b/convex/mercadopagoSubscriptionState.ts
@@ -2,30 +2,67 @@
 
 export const MP_FREE_TRIAL_DAYS = 14;
 
-export function isExpectedFreeTrial(value: unknown) {
+export function getFreeTrialDays(value: unknown) {
   if (typeof value !== "object" || value === null) {
-    return false;
+    return undefined;
   }
 
   const trial = value as Record<string, unknown>;
-  return (
-    trial.frequency === MP_FREE_TRIAL_DAYS && trial.frequency_type === "days"
-  );
+  return trial.frequency_type === "days" && typeof trial.frequency === "number"
+    ? trial.frequency
+    : undefined;
+}
+
+export function isExpectedFreeTrial(
+  value: unknown,
+  expectedDays: number | null,
+) {
+  const actualDays = getFreeTrialDays(value);
+  return expectedDays === null ? value == null : actualDays === expectedDays;
+}
+
+export function trialDaysForCheckout(hasConsumedTrial: boolean) {
+  return hasConsumedTrial ? null : MP_FREE_TRIAL_DAYS;
+}
+
+export function hasRemoteBillingActivity(
+  value:
+    | {
+        charged_quantity?: number | null;
+        last_charged_date?: string | null;
+      }
+    | null
+    | undefined,
+) {
+  return (value?.charged_quantity ?? 0) > 0 || value?.last_charged_date != null;
+}
+
+export function shouldBlockTrialActivation(
+  summary: Parameters<typeof hasRemoteBillingActivity>[0],
+  invoiceReconciliation: "empty" | "failed" | "processed" | undefined,
+) {
+  return hasRemoteBillingActivity(summary) || invoiceReconciliation !== "empty";
 }
 
 export function initialTrialEndsAt({
   existingTrialEndsAt,
+  hasBillingActivity,
+  hasPaymentState,
   mpStatus,
   nextPaymentDate,
   trialDays,
 }: {
   existingTrialEndsAt?: number;
+  hasBillingActivity: boolean;
+  hasPaymentState: boolean;
   mpStatus: string;
   nextPaymentDate?: string;
   trialDays?: number;
 }) {
   if (
     existingTrialEndsAt !== undefined ||
+    hasBillingActivity ||
+    hasPaymentState ||
     mpStatus !== "authorized" ||
     trialDays === undefined ||
     nextPaymentDate === undefined
@@ -39,6 +76,8 @@ export function initialTrialEndsAt({
 
 export function hasActivePaidEntitlement(
   row: {
+    lastPaymentId?: string;
+    paymentUpdatedAt?: number;
     status: string;
     paidThrough?: number;
     trialEndsAt?: number;
@@ -47,6 +86,9 @@ export function hasActivePaidEntitlement(
 ) {
   return (
     row.status === "active" &&
-    ((row.paidThrough ?? 0) > now || (row.trialEndsAt ?? 0) > now)
+    ((row.paidThrough ?? 0) > now ||
+      (row.lastPaymentId === undefined &&
+        row.paymentUpdatedAt === undefined &&
+        (row.trialEndsAt ?? 0) > now))
   );
 }

--- a/convex/mercadopagoSubscriptions.ts
+++ b/convex/mercadopagoSubscriptions.ts
@@ -266,6 +266,7 @@ export const applyPreapprovalState = zInternalMutation({
     reason: z.string().optional(),
     nextPaymentDate: z.string().optional(),
     remoteUpdatedAt: z.number().optional(),
+    hasBillingActivity: z.boolean(),
   }),
   handler: async (ctx, args) => {
     const existing = await ctx.db
@@ -286,6 +287,10 @@ export const applyPreapprovalState = zInternalMutation({
 
     const trialEndsAt = initialTrialEndsAt({
       existingTrialEndsAt: existing.trialEndsAt,
+      hasBillingActivity: args.hasBillingActivity,
+      hasPaymentState:
+        existing.lastPaymentId !== undefined ||
+        existing.paymentUpdatedAt !== undefined,
       mpStatus: args.mpStatus,
       nextPaymentDate: args.nextPaymentDate,
       trialDays: existing.trialDays,

--- a/convex/mercadopagoWebhooks.ts
+++ b/convex/mercadopagoWebhooks.ts
@@ -25,7 +25,10 @@ import {
   isMpPaidProductKey,
   MP_CURRENCY_ID,
 } from "./mercadopagoPlans";
-import { isExpectedFreeTrial } from "./mercadopagoSubscriptionState";
+import {
+  isExpectedFreeTrial,
+  shouldBlockTrialActivation,
+} from "./mercadopagoSubscriptionState";
 import { isWebhookTimestampWithinTolerance } from "./mercadopagoWebhookSignature";
 
 type InvoiceResponse = Awaited<ReturnType<Invoice["get"]>>;
@@ -38,6 +41,7 @@ interface StoredSubscription {
   externalReference?: string;
   lastInvoiceId?: string;
   trialDays?: number;
+  trialEndsAt?: number;
 }
 
 interface PaymentOverride {
@@ -81,7 +85,7 @@ function validateRemoteSubscription(
     recurring?.frequency === plan.frequency &&
     recurring?.frequency_type === plan.frequencyType &&
     (stored.trialDays === undefined ||
-      isExpectedFreeTrial(recurring?.free_trial))
+      isExpectedFreeTrial(recurring?.free_trial, stored.trialDays))
   );
 }
 
@@ -190,6 +194,34 @@ export async function processAuthorizedPayment(
   );
 
   return 200;
+}
+
+export async function reconcileSubscriptionInvoices(
+  ctx: ActionCtx,
+  preapprovalId: string,
+) {
+  try {
+    const found = await new Invoice(mpConfig()).search({
+      options: { preapproval_id: preapprovalId },
+    });
+    const invoices = [...(found.results ?? [])].sort(
+      (a, b) =>
+        parsedTimestamp(a.last_modified ?? a.date_created, 0) -
+        parsedTimestamp(b.last_modified ?? b.date_created, 0),
+    );
+
+    for (const invoice of invoices) {
+      await processAuthorizedPayment(ctx, invoice);
+    }
+
+    return invoices.length > 0 ? ("processed" as const) : ("empty" as const);
+  } catch (error) {
+    console.error(
+      `[mercadopago] no se pudieron consultar las facturas de ${preapprovalId}`,
+      error,
+    );
+    return "failed" as const;
+  }
 }
 
 async function processCreditPayment(
@@ -410,6 +442,14 @@ export const processWebhookEvent = zInternalAction({
       return 200;
     }
 
+    const invoiceReconciliation =
+      remote.status === "authorized" &&
+      stored.trialDays !== undefined &&
+      stored.trialEndsAt === undefined &&
+      stored.lastInvoiceId === undefined
+        ? await reconcileSubscriptionInvoices(ctx, args.dataId)
+        : undefined;
+
     await ctx.runMutation(
       internal.mercadopagoSubscriptions.applyPreapprovalState,
       {
@@ -419,6 +459,9 @@ export const processWebhookEvent = zInternalAction({
         reason: remote.reason,
         nextPaymentDate: remote.next_payment_date,
         remoteUpdatedAt: parsedTimestamp(remote.last_modified),
+        hasBillingActivity:
+          stored.lastInvoiceId !== undefined ||
+          shouldBlockTrialActivation(remote.summarized, invoiceReconciliation),
       },
     );
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -599,6 +599,8 @@ export const mercadopagoCheckoutAttempts = zodTable(
     leaseExpiresAt: z.number(),
     preapprovalId: z.string().optional(),
     initPoint: z.string().optional(),
+    /** Trial days, null when consumed, undefined on legacy attempts. */
+    trialDays: z.number().int().positive().nullable().optional(),
     createdAt: z.number(),
     updatedAt: z.number(),
   }),
@@ -755,6 +757,7 @@ export default defineSchema({
   mercadopagoSubscriptions: mercadopagoSubscriptions
     .table()
     .index("by_userId", ["userId"])
+    .index("by_userId_and_trialEndsAt", ["userId", "trialEndsAt"])
     .index("by_userId_and_status", ["userId", "status"])
     .index("by_userId_and_productKey", ["userId", "productKey"])
     .index("by_preapprovalId", ["preapprovalId"])

--- a/docs/mercadopago-subscriptions.md
+++ b/docs/mercadopago-subscriptions.md
@@ -42,10 +42,10 @@ The free plan has no remote preapproval because Mercado Pago cannot charge a zer
 The checkout action serializes creation per user and reuses one stable idempotency key for retries of the same intent:
 
 1. `createSubscriptionCheckout` validates the paid product key and uses a validated payer email or the authenticated account email.
-2. `mercadopagoCheckoutAttempts.acquire` atomically creates or resumes the per-user checkout claim.
+2. `mercadopagoCheckoutAttempts.acquire` atomically creates or resumes the per-user checkout claim and stores whether this account is still eligible for its one free trial.
 3. The action fetches every locally open preapproval from Mercado Pago. An unreachable or unverified remote state blocks checkout.
 4. The action cancels only remote preapprovals confirmed as abandoned and `pending`. Any live agreement blocks a second checkout.
-5. `PreApproval.create` receives the server-owned reference, catalog amount, interval, currency, 14-day free trial, and the claim's stable idempotency key.
+5. `PreApproval.create` receives the server-owned reference, catalog amount, interval, currency, and the claim's stable idempotency key. The 14-day free trial is included only when no earlier subscription row proves that this account already activated one.
 6. The completion mutation stores the preapproval and reusable hosted checkout URL in the same transaction.
 7. The browser redirects to Mercado Pago. Returning to PanaBarbero shows a pending state until Mercado Pago authorizes the trial or an approved payment proves access.
 
@@ -58,9 +58,9 @@ Agreement state and paid access are separate. A `subscription_preapproval` event
 Paid access requires both conditions:
 
 - The normalized agreement status is `active`
-- `trialEndsAt` or `paidThrough` is later than the current server time
+- An unused `trialEndsAt` or `paidThrough` is later than the current server time
 
-The first provider-confirmed `next_payment_date` fixes `trialEndsAt`; later agreement updates cannot extend it. Only a financially entitling authorized-payment invoice extends `paidThrough`. Approved and partially refunded payments keep the paid period; rejected or pending payments do not extend it. A full refund or unresolved chargeback against the payment that granted the current period revokes access, while a reimbursed chargeback restores it. Scheduled expiry mutations refresh reactive clients when a trial or unpaid period ends.
+The first provider-confirmed `next_payment_date` fixes `trialEndsAt` only while neither local payment state nor Mercado Pago's charge summary reports billing activity. Invoice reconciliation runs before a late agreement update can initialize trial access. Once any payment transition exists, entitlement comes only from `paidThrough`; an old trial timestamp cannot survive a refund or chargeback. Only a financially entitling authorized-payment invoice extends `paidThrough`. Approved and partially refunded payments keep the paid period; rejected or pending payments do not extend it. A full refund or unresolved chargeback against the payment that granted the current period revokes the affected access, while a reimbursed chargeback restores only the access removed by that chargeback. Scheduled expiry mutations refresh reactive clients when a trial or unpaid period ends.
 
 If a payment webhook is missed, the user can request reconciliation from the pricing card. The action fetches the authorized-payment page by preapproval and replays it oldest-first through the same validated idempotent recorder used by webhooks. Agreement authorization grants access only for a locally configured, provider-confirmed trial.
 
@@ -72,7 +72,7 @@ See Mercado Pago's [authorized payment lifecycle](https://www.mercadopago.com.co
 
 `cancelSubscription` changes the open preapproval to `cancelled` at Mercado Pago and verifies the returned terminal state before updating Convex. Cancellation is immediate: the paid entitlement stops because the agreement is no longer active, even if a prior `paidThrough` timestamp is still in the future.
 
-Users must cancel the current paid agreement before choosing another paid plan or returning to Free. A paused or authorized agreement still blocks a new checkout because it can resume billing. The free plan cannot be cancelled.
+Users must cancel the current paid agreement before choosing another paid plan or returning to Free. A paused or authorized agreement still blocks a new checkout because it can resume billing. Canceling a trial does not restore trial eligibility; later checkouts omit the free trial. The free plan cannot be cancelled.
 
 Account deletion removes the WorkOS login before any irreversible billing cancellation. Convex snapshots and expires still-payable Checkout Pro preferences, retains the subscription provider identifiers, and retries remote cancellation with bounded backoff before deleting billing rows. The same idempotent cleanup runs whether deletion starts in the app or externally in WorkOS.
 
@@ -111,7 +111,7 @@ Run billing tests through `/pricing` or the **Planes** profile tab. There is no 
 2. Push the current Convex functions with `pnpx convex dev --once`.
 3. Sign in with a PanaBarbero owner account and select a paid plan.
 4. Complete the hosted checkout with a Mercado Pago test buyer from the matching test application.
-5. Confirm the UI remains pending after authorization and becomes entitled only after an approved authorized-payment event.
+5. For a first-time trial checkout, confirm an active agreement plus a provider-confirmed future first-charge date grants the paid plan without an immediate charge. For a non-trial checkout, confirm access remains pending until an approved authorized-payment event. Paused and cancelled agreements must never qualify.
 6. Confirm a second checkout is blocked while the paid agreement is pending, authorized, or paused.
 7. Cancel from the **Planes** tab and confirm access ends immediately.
 8. Buy a credit pack and confirm one approved `payment` event grants it once.
@@ -123,7 +123,7 @@ Inspect webhook delivery in the Mercado Pago developer dashboard and billing sta
 
 Keep these rules intact when changing billing code:
 
-- Never grant access from a redirect, a client argument, or preapproval authorization alone
+- Never grant access from a redirect or client argument; preapproval authorization grants access only for the persisted, unused trial and its provider-confirmed first-charge date
 - Never create a remote checkout before persisting its server-owned identity and idempotency key
 - Never trust a webhook's mutable reference without matching a stored checkout and the local catalog
 - Never fail open when remote agreement state cannot be verified

--- a/tests/mercadopago-payment-state.test.ts
+++ b/tests/mercadopago-payment-state.test.ts
@@ -7,10 +7,14 @@ import {
 } from "../convex/mercadopagoPaymentState.ts";
 import { isWebhookTimestampWithinTolerance } from "../convex/mercadopagoWebhookSignature.ts";
 import {
+  getFreeTrialDays,
   hasActivePaidEntitlement,
+  hasRemoteBillingActivity,
   initialTrialEndsAt,
   isExpectedFreeTrial,
   MP_FREE_TRIAL_DAYS,
+  shouldBlockTrialActivation,
+  trialDaysForCheckout,
 } from "../convex/mercadopagoSubscriptionState.ts";
 
 const baseCreditState = {
@@ -247,14 +251,20 @@ test("partially refunded subscription payments remain financially entitling", ()
 
 test("the configured Mercado Pago trial is 14 days", () => {
   assert.equal(
-    isExpectedFreeTrial({
-      frequency: MP_FREE_TRIAL_DAYS,
-      frequency_type: "days",
-    }),
+    isExpectedFreeTrial(
+      {
+        frequency: MP_FREE_TRIAL_DAYS,
+        frequency_type: "days",
+      },
+      MP_FREE_TRIAL_DAYS,
+    ),
     true,
   );
   assert.equal(
-    isExpectedFreeTrial({ frequency: 7, frequency_type: "days" }),
+    isExpectedFreeTrial(
+      { frequency: 7, frequency_type: "days" },
+      MP_FREE_TRIAL_DAYS,
+    ),
     false,
   );
 });
@@ -263,6 +273,8 @@ test("an authorized trial grants paid access until the first charge", () => {
   const now = Date.parse("2026-07-10T12:00:00.000Z");
   const nextPaymentDate = "2026-07-24T12:00:00.000Z";
   const trialEndsAt = initialTrialEndsAt({
+    hasBillingActivity: false,
+    hasPaymentState: false,
     mpStatus: "authorized",
     nextPaymentDate,
     trialDays: MP_FREE_TRIAL_DAYS,
@@ -283,6 +295,8 @@ test("an authorized trial grants paid access until the first charge", () => {
   assert.equal(
     initialTrialEndsAt({
       existingTrialEndsAt: trialEndsAt,
+      hasBillingActivity: false,
+      hasPaymentState: false,
       mpStatus: "authorized",
       nextPaymentDate: "2026-07-25T12:00:00.000Z",
       trialDays: MP_FREE_TRIAL_DAYS,
@@ -299,6 +313,70 @@ test("cancellation revokes trial access immediately", () => {
       {
         status: "canceled",
         trialEndsAt: now + MP_FREE_TRIAL_DAYS * 24 * 60 * 60 * 1000,
+      },
+      now,
+    ),
+    false,
+  );
+});
+
+test("a consumed trial is not offered on a later checkout", () => {
+  assert.equal(trialDaysForCheckout(false), MP_FREE_TRIAL_DAYS);
+  assert.equal(trialDaysForCheckout(true), null);
+});
+
+test("historical trial durations validate against their persisted value", () => {
+  const remoteTrial = { frequency: 14, frequency_type: "days" };
+
+  assert.equal(getFreeTrialDays(remoteTrial), 14);
+  assert.equal(isExpectedFreeTrial(remoteTrial, 14), true);
+  assert.equal(isExpectedFreeTrial(remoteTrial, 7), false);
+  assert.equal(isExpectedFreeTrial(null, null), true);
+});
+
+test("billing activity cannot be minted into trial entitlement", () => {
+  const nextPaymentDate = "2026-08-10T12:00:00.000Z";
+
+  assert.equal(
+    initialTrialEndsAt({
+      hasBillingActivity: true,
+      hasPaymentState: false,
+      mpStatus: "authorized",
+      nextPaymentDate,
+      trialDays: MP_FREE_TRIAL_DAYS,
+    }),
+    undefined,
+  );
+  assert.equal(
+    initialTrialEndsAt({
+      hasBillingActivity: false,
+      hasPaymentState: true,
+      mpStatus: "authorized",
+      nextPaymentDate,
+      trialDays: MP_FREE_TRIAL_DAYS,
+    }),
+    undefined,
+  );
+  assert.equal(hasRemoteBillingActivity({ charged_quantity: 1 }), true);
+  assert.equal(shouldBlockTrialActivation(undefined, undefined), true);
+  assert.equal(shouldBlockTrialActivation(undefined, "failed"), true);
+  assert.equal(shouldBlockTrialActivation(undefined, "processed"), true);
+  assert.equal(shouldBlockTrialActivation(undefined, "empty"), false);
+  assert.equal(
+    shouldBlockTrialActivation({ charged_quantity: 1 }, "empty"),
+    true,
+  );
+});
+
+test("a payment transition disables historical trial entitlement", () => {
+  const now = Date.parse("2026-07-10T12:00:00.000Z");
+
+  assert.equal(
+    hasActivePaidEntitlement(
+      {
+        status: "active",
+        trialEndsAt: now + 24 * 60 * 60 * 1000,
+        paymentUpdatedAt: now,
       },
       now,
     ),


### PR DESCRIPTION
## What changed

Follow-up to merged PR #90 and its unresolved review threads.

- persist each checkout's trial decision atomically and allow only one activated trial per account
- omit the Mercado Pago trial after prior trial usage, including cancel/resubscribe flows
- reconcile invoices before initializing trial entitlement, failing closed unless the invoice search explicitly returns empty
- prevent payment, refund, or chargeback state from falling back to historical trial time
- preserve recovery for legacy checkout attempts created before trial eligibility was persisted
- validate existing subscriptions against their stored trial duration so later configuration changes do not break webhooks
- clarify trial/non-trial deployment verification and cancellation behavior

## Review coverage

Three independent subagent passes covered entitlement transitions, Mercado Pago/webhook behavior, schema migration, concurrency, idempotency, legacy recovery, and UI/backend divergence. CodeRabbit's first local pass also identified documentation clarifications that are included here. Its final repeat was rate-limited after the fixes.

## Verification

- `pnpm test:billing` (19 passing)
- `pnpx convex codegen`
- `pnpm exec tsc --noEmit`
- scoped Biome check and `git diff --check`
- `pnpm doctor:diff` (100/100)
- `pnpm build`

No UI components were changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mercado Pago trials now respect prior trial usage and stored trial duration.
  * Billing activity and payment history are considered when granting trial access.
  * Subscription invoices are reconciled automatically when needed.

* **Bug Fixes**
  * Prevented trial access from being incorrectly restored after billing activity, payments, cancellations, or chargebacks.
  * Improved validation of remote preapproval trial settings.

* **Documentation**
  * Clarified trial eligibility, paid access, cancellation, plan changes, and deployment verification rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->