### PR TITLE
feat(ci): add tag release pipeline

### DIFF
--- a/.github/RELEASES.md
+++ b/.github/RELEASES.md
@@ -2,18 +2,10 @@
 
 Pushing a SemVer tag starts the CLI-only release workflow:
 
-- `vX.Y.Z-<prerelease>` (rc, staging, demo, …) deploys Convex and Vercel
-  preview environments immediately — no quality checks, no approvals. All
-  prereleases of the same version share the `release-vX.Y.Z` Convex preview
-  deployment, so `-rc.2` reuses the backend and data `-rc.1` created.
-- `vX.Y.Z` runs the Biome and React Doctor workflows, then deploys production
-  through the `production` GitHub Environment (approval only if that
-  environment has required reviewers).
+- `vX.Y.Z-<prerelease>` (rc, staging, demo, …) deploys Convex and Vercel preview environments immediately — no quality checks, no approvals. All prereleases of the same version share the `release-vX-Y-Z` Convex preview deployment (dots become dashes; Convex deployment names only allow alphanumerics, dashes, and slashes), so `-rc.2` reuses the backend and data `-rc.1` created.
+- `vX.Y.Z` runs the Biome and React Doctor workflows as blocking gates (read-only `biome ci`; React Doctor fails the run on error-severity findings), then deploys production through the `production` GitHub Environment (approval only if that environment has required reviewers).
 
-The two paths are independent: a failed check only blocks production. Stable
-tags must point at a commit reachable from `origin/main`; prerelease tags may
-target any commit so previews can validate unmerged work. Tags are the only
-release trigger, so an agent or maintainer releases a verified commit with:
+The two paths are independent: a failed check only blocks production. Stable tags must point at a commit reachable from `origin/main`; prerelease tags may target any commit so previews can validate unmerged work. Tags are the only release trigger, so an agent or maintainer releases a verified commit with:
 
 ```sh
 git tag vX.Y.Z <verified-commit>
@@ -22,11 +14,7 @@ git push origin vX.Y.Z
 
 ## One-time GitHub configuration
 
-Create `preview` and `production` GitHub Environments. Keep their secrets
-separate, give `production` the required reviewers you want, and allow the
-`v*` tag pattern to deploy to each environment. To control who can trigger
-releases at all, add a repository ruleset that restricts creation of `v*`
-tags to release maintainers.
+Create `preview` and `production` GitHub Environments. Keep their secrets separate, give `production` the required reviewers you want, and allow the `v*` tag pattern to deploy to each environment. To control who can trigger releases at all, add a repository ruleset that restricts creation of `v*` tags to release maintainers.
 
 Each environment needs these secrets:
 
@@ -35,32 +23,19 @@ Each environment needs these secrets:
 | `VERCEL_TOKEN` | A Vercel token limited to this project/team. |
 | `CONVEX_DEPLOY_KEY` | A Preview Deploy Key in `preview`; a Production Deploy Key in `production`. |
 
-Create repository variables from the linked Vercel project (the local
-`.vercel/project.json` is intentionally ignored):
+Create repository variables from the linked Vercel project (the local `.vercel/project.json` is intentionally ignored):
 
 | Variable | Value |
 | --- | --- |
 | `VERCEL_ORG_ID` | Vercel team or user ID. |
 | `VERCEL_PROJECT_ID` | Vercel project ID. |
 
-The workflow pins every GitHub Action to its release commit and pins the Vercel
-CLI to the `VERCEL_CLI_VERSION` declared in `release.yml`. Convex uses the
-version locked in `pnpm-lock.yaml`.
+The workflow pins every GitHub Action to its release commit and pins the Vercel CLI to the `VERCEL_CLI_VERSION` declared in `release.yml`. Convex uses the version locked in `pnpm-lock.yaml`.
 
 ## Deployment model
 
-`convex deploy` detects TanStack Start and injects both `VITE_CONVEX_URL` and
-`VITE_CONVEX_SITE_URL` for the target deployment into the `vercel build` it
-invokes; the workflow then deploys Vercel's prebuilt output. This keeps each
-Vercel preview connected to its matching Convex preview deployment instead of a
-shared backend. The build runs with `CONVEX_DEPLOY_KEY` stripped from its
-environment so application build tooling never sees the deploy key.
+`convex deploy` detects TanStack Start and injects both `VITE_CONVEX_URL` and `VITE_CONVEX_SITE_URL` for the target deployment into the command it runs via `--cmd`; the workflow uses that command only to export the two URLs to `$GITHUB_ENV`, then runs `vercel build` in a separate step and deploys the prebuilt output. This keeps each Vercel preview connected to its matching Convex preview deployment instead of a shared backend, and the application build runs in a process tree that never held `CONVEX_DEPLOY_KEY` — build tooling cannot recover the deploy key from a parent environment. Convex functions are pushed before the frontend builds, so backend changes must stay backward compatible with the currently deployed frontend (already required by the push→deploy window).
 
-Convex preview deployments expire automatically (5 days on Free/Starter, 14 on
-Pro and above) and count toward the team deployment limit, so a preview release
-is a short-lived staging environment, not a persistent one.
+Convex preview deployments expire automatically (5 days on Free/Starter, 14 on Pro and above) and count toward the team deployment limit, so a preview release is a short-lived staging environment, not a persistent one.
 
-This workflow deliberately leaves the existing Vercel Git integration unchanged.
-If tags should become the only production deployment authority, disable Vercel's
-automatic Git deployments after this workflow has been tested; otherwise branch
-pushes can still create separate Vercel deployments outside the release gate.
+This workflow deliberately leaves the existing Vercel Git integration unchanged. If tags should become the only production deployment authority, disable Vercel's automatic Git deployments after this workflow has been tested; otherwise branch pushes can still create separate Vercel deployments outside the release gate.

--- a/.github/RELEASES.md
+++ b/.github/RELEASES.md
@@ -3,7 +3,7 @@
 Pushing a SemVer tag starts the CLI-only release workflow:
 
 - `vX.Y.Z-<prerelease>` (rc, staging, demo, …) deploys Convex and Vercel preview environments immediately — no quality checks, no approvals. All prereleases of the same version share the `release-vX-Y-Z` Convex preview deployment (dots become dashes; Convex deployment names only allow alphanumerics, dashes, and slashes), so `-rc.2` reuses the backend and data `-rc.1` created.
-- `vX.Y.Z` runs the Biome and React Doctor workflows as blocking gates (read-only `biome ci`; React Doctor fails the run on error-severity findings), then deploys production through the `production` GitHub Environment (approval only if that environment has required reviewers).
+- `vX.Y.Z` runs the Biome and React Doctor workflows as blocking gates (read-only `biome ci`; React Doctor fails the run on error-severity findings or an incomplete scan), then deploys production through the `production` GitHub Environment (approval only if that environment has required reviewers).
 
 The two paths are independent: a failed check only blocks production. Stable tags must point at a commit reachable from `origin/main`; prerelease tags may target any commit so previews can validate unmerged work. Tags are the only release trigger, so an agent or maintainer releases a verified commit with:
 

--- a/.github/RELEASES.md
+++ b/.github/RELEASES.md
@@ -2,14 +2,18 @@
 
 Pushing a SemVer tag starts the CLI-only release workflow:
 
-- `vX.Y.Z-<prerelease>` deploys isolated Convex and Vercel preview environments.
-- `vX.Y.Z` deploys preview first, then production after the `production` GitHub Environment approves it.
+- `vX.Y.Z-<prerelease>` (rc, staging, demo, …) deploys Convex and Vercel
+  preview environments immediately — no quality checks, no approvals. All
+  prereleases of the same version share the `release-vX.Y.Z` Convex preview
+  deployment, so `-rc.2` reuses the backend and data `-rc.1` created.
+- `vX.Y.Z` runs the Biome and React Doctor workflows, then deploys production
+  through the `production` GitHub Environment (approval only if that
+  environment has required reviewers).
 
-The release workflow calls the existing Biome and React Doctor workflows before
-either deployment. A failed check prevents every deployment. Stable tags must
-also point at a commit reachable from `origin/main`; prerelease tags may target
-any commit so previews can validate unmerged work. Tags are the only release
-trigger, so an agent or maintainer releases a verified commit with:
+The two paths are independent: a failed check only blocks production. Stable
+tags must point at a commit reachable from `origin/main`; prerelease tags may
+target any commit so previews can validate unmerged work. Tags are the only
+release trigger, so an agent or maintainer releases a verified commit with:
 
 ```sh
 git tag vX.Y.Z <verified-commit>
@@ -51,6 +55,10 @@ invokes; the workflow then deploys Vercel's prebuilt output. This keeps each
 Vercel preview connected to its matching Convex preview deployment instead of a
 shared backend. The build runs with `CONVEX_DEPLOY_KEY` stripped from its
 environment so application build tooling never sees the deploy key.
+
+Convex preview deployments expire automatically (5 days on Free/Starter, 14 on
+Pro and above) and count toward the team deployment limit, so a preview release
+is a short-lived staging environment, not a persistent one.
 
 This workflow deliberately leaves the existing Vercel Git integration unchanged.
 If tags should become the only production deployment authority, disable Vercel's

--- a/.github/RELEASES.md
+++ b/.github/RELEASES.md
@@ -1,0 +1,51 @@
+# Releases
+
+Pushing a SemVer tag starts the CLI-only release workflow:
+
+- `vX.Y.Z-<prerelease>` deploys isolated Convex and Vercel preview environments.
+- `vX.Y.Z` deploys preview first, then production after the `production` GitHub Environment approves it.
+
+The release workflow calls the existing Biome and React Doctor workflows before
+either deployment. A failed check prevents every deployment. Tags are the only
+release trigger, so an agent or maintainer releases a verified commit with:
+
+```sh
+git tag vX.Y.Z <verified-commit>
+git push origin vX.Y.Z
+```
+
+## One-time GitHub configuration
+
+Create `preview` and `production` GitHub Environments. Keep their secrets
+separate, give `production` the required reviewers you want, and allow the
+`v*` tag pattern to deploy to each environment.
+
+Each environment needs these secrets:
+
+| Secret | Value |
+| --- | --- |
+| `VERCEL_TOKEN` | A Vercel token limited to this project/team. |
+| `CONVEX_DEPLOY_KEY` | A Preview Deploy Key in `preview`; a Production Deploy Key in `production`. |
+
+Create repository variables from the linked Vercel project (the local
+`.vercel/project.json` is intentionally ignored):
+
+| Variable | Value |
+| --- | --- |
+| `VERCEL_ORG_ID` | Vercel team or user ID. |
+| `VERCEL_PROJECT_ID` | Vercel project ID. |
+
+The workflow pins every GitHub Action to its release commit and pins the Vercel
+CLI to `55.0.0`. Convex uses the version locked in `pnpm-lock.yaml`.
+
+## Deployment model
+
+`convex deploy` supplies the target `VITE_CONVEX_URL` while it invokes
+`vercel build`; the workflow derives the matching Convex Site URL for upload
+routes, then deploys Vercel's prebuilt output. This keeps each Vercel preview
+connected to its matching Convex preview deployment instead of a shared backend.
+
+This workflow deliberately leaves the existing Vercel Git integration unchanged.
+If tags should become the only production deployment authority, disable Vercel's
+automatic Git deployments after this workflow has been tested; otherwise branch
+pushes can still create separate Vercel deployments outside the release gate.

--- a/.github/RELEASES.md
+++ b/.github/RELEASES.md
@@ -6,8 +6,10 @@ Pushing a SemVer tag starts the CLI-only release workflow:
 - `vX.Y.Z` deploys preview first, then production after the `production` GitHub Environment approves it.
 
 The release workflow calls the existing Biome and React Doctor workflows before
-either deployment. A failed check prevents every deployment. Tags are the only
-release trigger, so an agent or maintainer releases a verified commit with:
+either deployment. A failed check prevents every deployment. Stable tags must
+also point at a commit reachable from `origin/main`; prerelease tags may target
+any commit so previews can validate unmerged work. Tags are the only release
+trigger, so an agent or maintainer releases a verified commit with:
 
 ```sh
 git tag vX.Y.Z <verified-commit>
@@ -18,7 +20,9 @@ git push origin vX.Y.Z
 
 Create `preview` and `production` GitHub Environments. Keep their secrets
 separate, give `production` the required reviewers you want, and allow the
-`v*` tag pattern to deploy to each environment.
+`v*` tag pattern to deploy to each environment. To control who can trigger
+releases at all, add a repository ruleset that restricts creation of `v*`
+tags to release maintainers.
 
 Each environment needs these secrets:
 
@@ -36,14 +40,17 @@ Create repository variables from the linked Vercel project (the local
 | `VERCEL_PROJECT_ID` | Vercel project ID. |
 
 The workflow pins every GitHub Action to its release commit and pins the Vercel
-CLI to `55.0.0`. Convex uses the version locked in `pnpm-lock.yaml`.
+CLI to the `VERCEL_CLI_VERSION` declared in `release.yml`. Convex uses the
+version locked in `pnpm-lock.yaml`.
 
 ## Deployment model
 
-`convex deploy` supplies the target `VITE_CONVEX_URL` while it invokes
-`vercel build`; the workflow derives the matching Convex Site URL for upload
-routes, then deploys Vercel's prebuilt output. This keeps each Vercel preview
-connected to its matching Convex preview deployment instead of a shared backend.
+`convex deploy` detects TanStack Start and injects both `VITE_CONVEX_URL` and
+`VITE_CONVEX_SITE_URL` for the target deployment into the `vercel build` it
+invokes; the workflow then deploys Vercel's prebuilt output. This keeps each
+Vercel preview connected to its matching Convex preview deployment instead of a
+shared backend. The build runs with `CONVEX_DEPLOY_KEY` stripped from its
+environment so application build tooling never sees the deploy key.
 
 This workflow deliberately leaves the existing Vercel Git integration unchanged.
 If tags should become the only production deployment authority, disable Vercel's

--- a/.github/setup/action.yaml
+++ b/.github/setup/action.yaml
@@ -5,12 +5,12 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v5
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       with:
         run_install: false
 
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: "24"
         cache: pnpm

--- a/.github/setup/action.yaml
+++ b/.github/setup/action.yaml
@@ -5,12 +5,12 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       with:
         run_install: false
 
     - name: Setup Node.js
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "24"
         cache: pnpm

--- a/.github/workflows/biome.yaml
+++ b/.github/workflows/biome.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/biome.yaml
+++ b/.github/workflows/biome.yaml
@@ -25,8 +25,5 @@ jobs:
       - name: Setup
         uses: ./.github/setup
 
-      - name: Lint
-        run: pnpm lint
-
-      - name: Format
-        run: pnpm format
+      - name: Check
+        run: pnpm exec biome ci .

--- a/.github/workflows/biome.yaml
+++ b/.github/workflows/biome.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup
         uses: ./.github/setup

--- a/.github/workflows/biome.yaml
+++ b/.github/workflows/biome.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches: ["main"]
   merge_group:
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -25,3 +25,7 @@ jobs:
           persist-credentials: false
       - name: Runs React Doctor
         uses: millionco/react-doctor@ced746f518f11e8283d488c4ff31c44e478bb0e5 # v2.2.6
+        with:
+          # Advisory on pull requests, blocking when called from the release
+          # workflow on a tag push.
+          blocking: ${{ github.ref_type == 'tag' && 'error' || 'none' }}

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Runs React Doctor
-        uses: millionco/react-doctor@ced746f518f11e8283d488c4ff31c44e478bb0e5 # v2
+        uses: millionco/react-doctor@ced746f518f11e8283d488c4ff31c44e478bb0e5 # v2.2.6

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -22,5 +22,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Runs React Doctor
         uses: millionco/react-doctor@ced746f518f11e8283d488c4ff31c44e478bb0e5 # v2.2.6

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -3,6 +3,7 @@ name: React Doctor
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_call:
 
 permissions:
   contents: read
@@ -18,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
       - name: Runs React Doctor
-        uses: millionco/react-doctor@v2
+        uses: millionco/react-doctor@ced746f518f11e8283d488c4ff31c44e478bb0e5 # v2

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -24,8 +24,23 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Runs React Doctor
-        uses: millionco/react-doctor@ced746f518f11e8283d488c4ff31c44e478bb0e5 # v2.2.6
-        with:
-          # Advisory on pull requests, blocking when called from the release
-          # workflow on a tag push.
-          blocking: ${{ github.ref_type == 'tag' && 'error' || 'none' }}
+        id: doctor
+        uses: millionco/react-doctor@938008119a288f2fb47c66a69cd9279a21f31784 # v2.2.7
+
+      # The action never fails on findings for non-PR events, so gate release
+      # (tag) runs on its outputs: block on error-severity findings or on a
+      # scan that produced no score (i.e. it never completed).
+      - name: Enforce release gate
+        if: github.ref_type == 'tag'
+        env:
+          ERROR_COUNT: ${{ steps.doctor.outputs.error-count }}
+          SCORE: ${{ steps.doctor.outputs.score }}
+        run: |
+          if [ -z "$SCORE" ]; then
+            echo "React Doctor scan did not complete; blocking the release." >&2
+            exit 1
+          fi
+          if [ "${ERROR_COUNT:-0}" != "0" ]; then
+            echo "React Doctor found ${ERROR_COUNT} error-severity issue(s); blocking the release." >&2
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  VERCEL_CLI_VERSION: "55.0.0"
+  VERCEL_CLI_VERSION: "56.3.0"
   VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
 
@@ -40,6 +40,22 @@ jobs:
             echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Checkout
+        if: steps.tag.outputs.is_prerelease == 'false'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Require stable tags to point at main
+        if: steps.tag.outputs.is_prerelease == 'false'
+        run: |
+          commit="$(git rev-parse "${GITHUB_SHA}^{commit}")"
+          if ! git merge-base --is-ancestor "$commit" origin/main; then
+            echo "Stable release tags must point at a commit reachable from origin/main." >&2
+            exit 1
+          fi
+
   biome:
     name: Biome
     uses: ./.github/workflows/biome.yaml
@@ -60,6 +76,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup
         uses: ./.github/setup
@@ -74,9 +91,8 @@ jobs:
           CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
           RELEASE_TAG: ${{ github.ref_name }}
         run: >-
-          pnpm exec convex deploy --preview-name "release-${RELEASE_TAG}"
-          --cmd-url-env-var-name VITE_CONVEX_URL
-          --cmd 'VITE_CONVEX_SITE_URL="${VITE_CONVEX_URL/.cloud/.site}" pnpm dlx "vercel@${VERCEL_CLI_VERSION}" build'
+          pnpm convex deploy --preview-name "release-${RELEASE_TAG}"
+          --cmd 'env -u CONVEX_DEPLOY_KEY pnpm dlx "vercel@${VERCEL_CLI_VERSION}" build'
 
       - name: Deploy Vercel preview
         id: deploy
@@ -92,6 +108,9 @@ jobs:
     needs: [validate-tag, preview]
     if: ${{ needs.validate-tag.outputs.is_prerelease == 'false' }}
     runs-on: ubuntu-latest
+    concurrency:
+      group: release-production
+      cancel-in-progress: false
     environment:
       name: production
       url: ${{ steps.deploy.outputs.url }}
@@ -100,6 +119,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup
         uses: ./.github/setup
@@ -113,8 +133,7 @@ jobs:
         env:
           CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
         run: >-
-          pnpm exec convex deploy --cmd-url-env-var-name VITE_CONVEX_URL
-          --cmd 'VITE_CONVEX_SITE_URL="${VITE_CONVEX_URL/.cloud/.site}" pnpm dlx "vercel@${VERCEL_CLI_VERSION}" build --prod'
+          pnpm convex deploy --cmd 'env -u CONVEX_DEPLOY_KEY pnpm dlx "vercel@${VERCEL_CLI_VERSION}" build --prod'
 
       - name: Deploy Vercel production
         id: deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,10 @@ jobs:
     name: React Doctor
     needs: validate-tag
     if: ${{ needs.validate-tag.outputs.is_prerelease == 'false' }}
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     uses: ./.github/workflows/react-doctor.yml
 
   preview:
@@ -91,13 +95,19 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: pnpm dlx "vercel@${VERCEL_CLI_VERSION}" pull --yes --environment=preview
 
-      - name: Deploy Convex preview and build Vercel artifact
+      # --cmd only exports the injected deployment URLs; the app build runs in
+      # the next step, in a process tree that never held CONVEX_DEPLOY_KEY.
+      - name: Deploy Convex preview
         env:
           CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
           RELEASE_TAG: ${{ github.ref_name }}
-        run: >-
-          pnpm convex deploy --preview-name "release-${RELEASE_TAG%%-*}"
-          --cmd 'env -u CONVEX_DEPLOY_KEY pnpm dlx "vercel@${VERCEL_CLI_VERSION}" build'
+        run: |
+          base="${RELEASE_TAG%%-*}"
+          pnpm convex deploy --preview-name "release-${base//./-}" \
+            --cmd 'echo "VITE_CONVEX_URL=$VITE_CONVEX_URL" >> "$GITHUB_ENV" && echo "VITE_CONVEX_SITE_URL=$VITE_CONVEX_SITE_URL" >> "$GITHUB_ENV"'
+
+      - name: Build Vercel artifact
+        run: pnpm dlx "vercel@${VERCEL_CLI_VERSION}" build
 
       - name: Deploy Vercel preview
         id: deploy
@@ -134,11 +144,16 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: pnpm dlx "vercel@${VERCEL_CLI_VERSION}" pull --yes --environment=production
 
-      - name: Deploy Convex production and build Vercel artifact
+      # Same split as the preview job: the build never sees CONVEX_DEPLOY_KEY.
+      - name: Deploy Convex production
         env:
           CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
         run: >-
-          pnpm convex deploy --cmd 'env -u CONVEX_DEPLOY_KEY pnpm dlx "vercel@${VERCEL_CLI_VERSION}" build --prod'
+          pnpm convex deploy
+          --cmd 'echo "VITE_CONVEX_URL=$VITE_CONVEX_URL" >> "$GITHUB_ENV" && echo "VITE_CONVEX_SITE_URL=$VITE_CONVEX_SITE_URL" >> "$GITHUB_ENV"'
+
+      - name: Build Vercel artifact
+        run: pnpm dlx "vercel@${VERCEL_CLI_VERSION}" build --prod
 
       - name: Deploy Vercel production
         id: deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,15 +58,20 @@ jobs:
 
   biome:
     name: Biome
+    needs: validate-tag
+    if: ${{ needs.validate-tag.outputs.is_prerelease == 'false' }}
     uses: ./.github/workflows/biome.yaml
 
   react-doctor:
     name: React Doctor
+    needs: validate-tag
+    if: ${{ needs.validate-tag.outputs.is_prerelease == 'false' }}
     uses: ./.github/workflows/react-doctor.yml
 
   preview:
     name: Deploy preview
-    needs: [validate-tag, biome, react-doctor]
+    needs: validate-tag
+    if: ${{ needs.validate-tag.outputs.is_prerelease == 'true' }}
     runs-on: ubuntu-latest
     environment:
       name: preview
@@ -91,7 +96,7 @@ jobs:
           CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
           RELEASE_TAG: ${{ github.ref_name }}
         run: >-
-          pnpm convex deploy --preview-name "release-${RELEASE_TAG}"
+          pnpm convex deploy --preview-name "release-${RELEASE_TAG%%-*}"
           --cmd 'env -u CONVEX_DEPLOY_KEY pnpm dlx "vercel@${VERCEL_CLI_VERSION}" build'
 
       - name: Deploy Vercel preview
@@ -105,7 +110,7 @@ jobs:
 
   production:
     name: Deploy production
-    needs: [validate-tag, preview]
+    needs: [validate-tag, biome, react-doctor]
     if: ${{ needs.validate-tag.outputs.is_prerelease == 'false' }}
     runs-on: ubuntu-latest
     concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       url: ${{ steps.deploy.outputs.url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -97,7 +97,7 @@ jobs:
       url: ${{ steps.deploy.outputs.url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,126 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  VERCEL_CLI_VERSION: "55.0.0"
+  VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+
+jobs:
+  validate-tag:
+    name: Validate release tag
+    runs-on: ubuntu-latest
+    outputs:
+      is_prerelease: ${{ steps.tag.outputs.is_prerelease }}
+    steps:
+      - name: Validate semantic version
+        id: tag
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Release tags must use vMAJOR.MINOR.PATCH with optional SemVer prerelease/build metadata." >&2
+            exit 1
+          fi
+
+          tag_without_build_metadata="${RELEASE_TAG%%+*}"
+          if [[ "$tag_without_build_metadata" == *-* ]]; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  biome:
+    name: Biome
+    uses: ./.github/workflows/biome.yaml
+
+  react-doctor:
+    name: React Doctor
+    uses: ./.github/workflows/react-doctor.yml
+
+  preview:
+    name: Deploy preview
+    needs: [validate-tag, biome, react-doctor]
+    runs-on: ubuntu-latest
+    environment:
+      name: preview
+      url: ${{ steps.deploy.outputs.url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup
+        uses: ./.github/setup
+
+      - name: Pull Vercel preview settings
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: pnpm dlx "vercel@${VERCEL_CLI_VERSION}" pull --yes --environment=preview
+
+      - name: Deploy Convex preview and build Vercel artifact
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: >-
+          pnpm exec convex deploy --preview-name "release-${RELEASE_TAG}"
+          --cmd-url-env-var-name VITE_CONVEX_URL
+          --cmd 'VITE_CONVEX_SITE_URL="${VITE_CONVEX_URL/.cloud/.site}" pnpm dlx "vercel@${VERCEL_CLI_VERSION}" build'
+
+      - name: Deploy Vercel preview
+        id: deploy
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          url="$(pnpm dlx "vercel@${VERCEL_CLI_VERSION}" deploy --prebuilt --yes --meta "githubCommitSha=${GITHUB_SHA}" --meta "releaseTag=${RELEASE_TAG}")"
+          echo "url=${url}" >> "$GITHUB_OUTPUT"
+
+  production:
+    name: Deploy production
+    needs: [validate-tag, preview]
+    if: ${{ needs.validate-tag.outputs.is_prerelease == 'false' }}
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: ${{ steps.deploy.outputs.url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup
+        uses: ./.github/setup
+
+      - name: Pull Vercel production settings
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: pnpm dlx "vercel@${VERCEL_CLI_VERSION}" pull --yes --environment=production
+
+      - name: Deploy Convex production and build Vercel artifact
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+        run: >-
+          pnpm exec convex deploy --cmd-url-env-var-name VITE_CONVEX_URL
+          --cmd 'VITE_CONVEX_SITE_URL="${VITE_CONVEX_URL/.cloud/.site}" pnpm dlx "vercel@${VERCEL_CLI_VERSION}" build --prod'
+
+      - name: Deploy Vercel production
+        id: deploy
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          url="$(pnpm dlx "vercel@${VERCEL_CLI_VERSION}" deploy --prebuilt --prod --yes --meta "githubCommitSha=${GITHUB_SHA}" --meta "releaseTag=${RELEASE_TAG}")"
+          echo "url=${url}" >> "$GITHUB_OUTPUT"

--- a/convex/dashboardAnalytics.ts
+++ b/convex/dashboardAnalytics.ts
@@ -113,7 +113,10 @@ export const getOperationsBreakdown = zAuthQuery({
       ctx.db
         .query("appointments")
         .withIndex("by_barbershopId_and_date", (q) =>
-          q.eq("barbershopId", barbershopId).gte("date", since).lte("date", now),
+          q
+            .eq("barbershopId", barbershopId)
+            .gte("date", since)
+            .lte("date", now),
         )
         .collect(),
       ctx.db

--- a/convex/inAppNotifications.ts
+++ b/convex/inAppNotifications.ts
@@ -1,5 +1,5 @@
-import { convexToZod } from "convex-helpers/server/zod4";
 import { paginationOptsValidator } from "convex/server";
+import { convexToZod } from "convex-helpers/server/zod4";
 import { z } from "zod";
 
 import { zAuthMutation, zAuthQuery, zInternalMutation } from ".";

--- a/convex/index.ts
+++ b/convex/index.ts
@@ -1,3 +1,5 @@
+import { defineTable } from "convex/server";
+import type { GenericId } from "convex/values";
 import { customCtx, NoOp } from "convex-helpers/server/customFunctions";
 import {
   zCustomAction,
@@ -6,8 +8,6 @@ import {
   zid,
   zodToConvex,
 } from "convex-helpers/server/zod4";
-import { defineTable } from "convex/server";
-import type { GenericId } from "convex/values";
 import { z } from "zod";
 
 import type { ActionCtx, MutationCtx, QueryCtx } from "./_generated/server";

--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -1,6 +1,6 @@
 import type { Locale } from "@workos-inc/node";
-import { zid } from "convex-helpers/server/zod4";
 import { ConvexError } from "convex/values";
+import { zid } from "convex-helpers/server/zod4";
 import { z } from "zod";
 
 import { zAuthAction, zInternalMutation, zInternalQuery } from ".";

--- a/convex/log.ts
+++ b/convex/log.ts
@@ -1,5 +1,5 @@
-import { AuditLog } from "convex-audit-log";
 import { ConvexError } from "convex/values";
+import { AuditLog } from "convex-audit-log";
 import { z } from "zod";
 
 import { zAuthQuery } from ".";

--- a/src/components/landing/cta-section.tsx
+++ b/src/components/landing/cta-section.tsx
@@ -1,6 +1,6 @@
 import { ArrowRightIcon } from "@phosphor-icons/react";
 import { Link } from "@tanstack/react-router";
-import { LazyMotion, domAnimation, m, useInView } from "motion/react";
+import { domAnimation, LazyMotion, m, useInView } from "motion/react";
 import type { FC } from "react";
 import { useRef } from "react";
 

--- a/src/components/landing/notifications-section.tsx
+++ b/src/components/landing/notifications-section.tsx
@@ -10,8 +10,8 @@ import {
   XCircleIcon,
 } from "@phosphor-icons/react";
 import {
-  animate,
   AnimatePresence,
+  animate,
   domAnimation,
   LazyMotion,
   m,

--- a/src/components/ui/ai/message.tsx
+++ b/src/components/ui/ai/message.tsx
@@ -1,9 +1,9 @@
-import { cn } from "@/lib/utils";
 import { cjk } from "@streamdown/cjk";
 import type { UIMessage } from "ai";
 import type { ComponentProps, HTMLAttributes } from "react";
 import { memo } from "react";
 import { Streamdown } from "streamdown";
+import { cn } from "@/lib/utils";
 
 export type MessageProps = HTMLAttributes<HTMLDivElement> & {
   from: UIMessage["role"];

--- a/src/components/ui/ai/prompt-input.tsx
+++ b/src/components/ui/ai/prompt-input.tsx
@@ -1,17 +1,9 @@
 import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupButton,
-  InputGroupTextarea,
-} from "@/components/ui/input-group";
-import { Spinner } from "@/components/ui/spinner";
-import { cn } from "@/lib/utils";
-import type { ChatStatus, FileUIPart, SourceDocumentUIPart } from "ai";
-import {
   ArrowBendDownLeftIcon,
   SquareIcon,
   XIcon,
 } from "@phosphor-icons/react";
+import type { ChatStatus, FileUIPart, SourceDocumentUIPart } from "ai";
 import type {
   ChangeEvent,
   ChangeEventHandler,
@@ -32,6 +24,14 @@ import {
   useRef,
   useState,
 } from "react";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupTextarea,
+} from "@/components/ui/input-group";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
 
 // ============================================================================
 // Helpers

--- a/src/components/ui/ai/shimmer.tsx
+++ b/src/components/ui/ai/shimmer.tsx
@@ -1,8 +1,8 @@
-import { cn } from "@/lib/utils";
 import type { MotionProps } from "motion/react";
 import { domAnimation, LazyMotion, m } from "motion/react";
 import type { CSSProperties, ElementType, JSX } from "react";
 import { memo, useMemo } from "react";
+import { cn } from "@/lib/utils";
 
 type MotionHTMLProps = MotionProps & Record<string, unknown>;
 

--- a/src/components/ui/ai/suggestion.tsx
+++ b/src/components/ui/ai/suggestion.tsx
@@ -1,8 +1,8 @@
+import type { ComponentProps } from "react";
+import { useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
-import type { ComponentProps } from "react";
-import { useCallback } from "react";
 
 export type SuggestionsProps = ComponentProps<typeof ScrollArea>;
 

--- a/src/components/ui/empty.tsx
+++ b/src/components/ui/empty.tsx
@@ -1,5 +1,5 @@
-import type { ComponentProps } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
+import type { ComponentProps } from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/src/components/ui/input-group.tsx
+++ b/src/components/ui/input-group.tsx
@@ -1,10 +1,9 @@
-import type { ComponentProps, KeyboardEvent, MouseEvent } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
-
-import { cn } from "@/lib/utils";
+import type { ComponentProps, KeyboardEvent, MouseEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
 
 function InputGroup({ className, ...props }: ComponentProps<"fieldset">) {
   return (

--- a/src/hooks/barbershop/use-barbershop-member.ts
+++ b/src/hooks/barbershop/use-barbershop-member.ts
@@ -1,5 +1,5 @@
-import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@convex/_generated/api";
+import { convexQuery } from "@convex-dev/react-query";
 import { useQuery } from "@tanstack/react-query";
 
 export function barbershopMemberRolesQueryOptions(userId: string) {

--- a/src/hooks/use-notifications.ts
+++ b/src/hooks/use-notifications.ts
@@ -1,5 +1,5 @@
-import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
 import { api } from "@convex/_generated/api";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 
 export function recentNotificationsQueryOptions() {

--- a/src/hooks/use-profile-photo-actions.ts
+++ b/src/hooks/use-profile-photo-actions.ts
@@ -1,5 +1,5 @@
-import { useConvexMutation } from "@convex-dev/react-query";
 import { api } from "@convex/_generated/api";
+import { useConvexMutation } from "@convex-dev/react-query";
 import { useMutation } from "@tanstack/react-query";
 
 export function useProfilePhotoActions() {

--- a/src/hooks/use-services.ts
+++ b/src/hooks/use-services.ts
@@ -1,6 +1,6 @@
-import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
 import { api } from "@convex/_generated/api";
 import type { Appointment, Barbershop, Service } from "@convex/schema";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
 import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
 
 function useCreateServiceMutation() {

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,8 +1,8 @@
+import rehypeSlug from "rehype-slug";
+import rehypeStringify from "rehype-stringify";
 import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
-import rehypeSlug from "rehype-slug";
-import rehypeStringify from "rehype-stringify";
 import { unified } from "unified";
 
 export async function renderMarkdown(content: string): Promise<string> {


### PR DESCRIPTION
## Summary
- add SemVer tag releases that gate preview and production deployments on the existing Biome and React Doctor workflows
- deploy Convex and Vercel through their CLIs with isolated preview deployments and production Environment protection
- pin GitHub Actions to release SHAs and document the required GitHub Environment secrets and variables

## Verification
- `pnpm build`
- YAML parsing
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tag-driven release process with SemVer validation, including prerelease preview deployments and stable releases that route through preview before production approval.
  * Automated quality checks as part of the release pipeline.
  * Added release documentation covering setup, versioning, and deployment behavior.

* **Chores**
  * Improved workflow reuse by allowing shared quality-check workflows to be invoked from other workflows.
  * Increased reliability and security by pinning action versions and tightening checkout configuration (full history, no persisted credentials).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->