### PR TITLE
feat(appointments): add variable pricing and multi-service booking

### DIFF
--- a/.github/workflows/pullfrog.yaml
+++ b/.github/workflows/pullfrog.yaml
@@ -1,0 +1,37 @@
+name: Pullfrog
+
+run-name: ${{ inputs.name || github.workflow }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      prompt:
+        type: string
+        description: Agent prompt
+      name:
+        type: string
+        description: Run name
+
+permissions:
+  contents: read
+
+jobs:
+  pullfrog:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup
+        uses: ./.github/setup
+
+      - name: Run Pullfrog agent
+        uses: pullfrog/pullfrog@0835cd587949ed3beaabeeb94e2ff8b5c2f07f0e # v0.1.46
+        with:
+          prompt: ${{ inputs.prompt }}

--- a/.github/workflows/pullfrog.yaml
+++ b/.github/workflows/pullfrog.yaml
@@ -15,12 +15,17 @@ on:
 permissions:
   contents: read
 
+# One agent run per ref: overlapping runs would review the same code twice.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   pullfrog:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      contents: read
+      id-token: write # Pullfrog authenticates via GitHub OIDC.
+      contents: read # Checkout only; the agent never pushes.
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -144,8 +144,9 @@ const form = useAppForm({
   Functions live in `convex/reviews.ts`; the gateway-LLM moderation action is in
   `convex/reviewModeration.ts` (a `"use node"` file — see §3).
 - **Appointments are line-item based.** `appointments.items[]` is canonical:
-  each line snapshots `serviceId/name/price/priceType/duration` (+ optional
-  `finalPrice`) at booking time; `appointments.serviceId` is only the
+  each line snapshots `serviceId/name/price/priceType/duration` at booking
+  time and completion adds `finalPrice` to `"starting"` lines;
+  `appointments.serviceId` is only the
   denormalized primary line (≡ `items[0].serviceId`, kept for `by_serviceId`
   and legacy readers). ALL line math (totals, joined labels, overlap widths)
   goes through `convex/appointmentItems.ts` — never hand-roll it. Booking

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -143,6 +143,36 @@ const form = useAppForm({
   `@convex-dev/workpool` pool `reviewModerationWorkpool` (async review moderation).
   Functions live in `convex/reviews.ts`; the gateway-LLM moderation action is in
   `convex/reviewModeration.ts` (a `"use node"` file — see §3).
+- **Appointments are line-item based.** `appointments.items[]` is canonical:
+  each line snapshots `serviceId/name/price/priceType/duration` (+ optional
+  `finalPrice`) at booking time; `appointments.serviceId` is only the
+  denormalized primary line (≡ `items[0].serviceId`, kept for `by_serviceId`
+  and legacy readers). ALL line math (totals, joined labels, overlap widths)
+  goes through `convex/appointmentItems.ts` — never hand-roll it. Booking
+  entry points (`create`, `agentBook`, the Pana `serviceIds[]` proposals) take
+  `serviceIds` arrays; availability/overlap use the summed duration, and
+  `conflictDurationMinutes` keeps the legacy `liveService?.duration ?? 0`
+  chain for pre-backfill rows.
+- **"Desde" pricing + completion finals.** `services.priceType`
+  `"starting"` marks the listed price as a binding minimum ("Desde $X").
+  `setStatus("completed")` REQUIRES a `finalPrices` entry ≥ the minimum for
+  every starting line, and patches the row's items in the same transaction as
+  the `completedAppointmentsAggregate` insert (total = Σ finalPrice ?? price;
+  `completedServicePrice/Name` become total / joined-label mirrors). No
+  post-completion edits (v1). Reviews snapshot the joined label
+  ("Corte + Barba") as `serviceName`; `serviceId` stays the primary line.
+- **`deleteService` drop-line semantics.** The sweep scans the shop's future
+  active citas via `by_barbershopId_and_date`: sole-line citas cancel (today's
+  flow), multi-line citas drop the line (block shrinks from the tail,
+  `serviceId` re-points, that line's inventory hold is released via
+  `releaseServiceLineForAppointment`, customers get `service_line_removed`).
+  Two-step confirm throws `WILL_CANCEL:N:WILL_UPDATE:M`.
+- **Migrations** live in `convex/migrations.ts`; run with
+  `npx convex run migrations:run '{fn: "migrations:<name>"}'` (add `--prod`
+  for production). After the multi-service deploy, run
+  `backfillAppointmentItems` once per deployment to synthesize a single fixed
+  line onto pre-existing rows (skips rows that already carry `items`; never
+  touches the revenue aggregate).
 
 **Relations:** §1.1 (the hook that reads it), §2 (identity), §3 (roles/plans
 that gate it), `convex-functions` / `convex-security-check` skills.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -149,7 +149,10 @@ const form = useAppForm({
   `appointments.serviceId` is only the
   denormalized primary line (≡ `items[0].serviceId`, kept for `by_serviceId`
   and legacy readers). ALL line math (totals, joined labels, overlap widths)
-  goes through `convex/appointmentItems.ts` — never hand-roll it. Booking
+  goes through `convex/appointmentItems.ts` — never hand-roll it. The client
+  mirror lives in `src/lib/appointment-utils.ts`
+  (`appointmentItemsLabel`/`appointmentItemsDuration`) and must stay
+  semantically aligned. Booking
   entry points (`create`, `agentBook`, the Pana `serviceIds[]` proposals) take
   `serviceIds` arrays; availability/overlap use the summed duration, and
   `conflictDurationMinutes` keeps the legacy `liveService?.duration ?? 0`

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -17,6 +17,7 @@ import type * as aiChat from "../aiChat.js";
 import type * as aiRag from "../aiRag.js";
 import type * as aiStream from "../aiStream.js";
 import type * as analytics from "../analytics.js";
+import type * as appointmentItems from "../appointmentItems.js";
 import type * as appointments from "../appointments.js";
 import type * as auth from "../auth.js";
 import type * as authz from "../authz.js";
@@ -85,6 +86,7 @@ declare const fullApi: ApiFromModules<{
   aiRag: typeof aiRag;
   aiStream: typeof aiStream;
   analytics: typeof analytics;
+  appointmentItems: typeof appointmentItems;
   appointments: typeof appointments;
   auth: typeof auth;
   authz: typeof authz;

--- a/convex/aiAgent.ts
+++ b/convex/aiAgent.ts
@@ -145,8 +145,8 @@ Lectura — consultan, no cambian nada:
 - searchBarbershops: barberías por nombre, ciudad o departamento. Puerta de entrada de un CLIENTE que busca dónde ir.
 - getBarbershopDetails: ficha de una barbería (servicios con precio y duración, horario, contacto). Necesita el uuid de searchBarbershops.
 - getBarbershopTeam: barberos de una barbería (solo nombres), cuando preguntan "¿quién atiende?" sin servicio elegido.
-- listBarbersForService: barberos que prestan un servicio puntual (da el barbershopMemberId). Dentro del flujo de reserva de un cliente.
-- getAvailability: horarios libres (HH:MM) de un barbero pa' un servicio en una fecha (AAAA-MM-DD). Úsala SIEMPRE antes de proponer/confirmar una hora.
+- listBarbersForService: barberos que prestan TODOS los servicios seleccionados (da el barbershopMemberId). Dentro del flujo de reserva de un cliente.
+- getAvailability: horarios libres (HH:MM) de un barbero pa' uno o varios servicios en una fecha (AAAA-MM-DD); la cita ocupa un solo bloque con la suma de las duraciones. Úsala SIEMPRE antes de proponer/confirmar una hora.
 - getMyAppointments: las citas del usuario COMO CLIENTE (las que él reservó). Requiere sesión. Úsala antes de cancelar o reagendar como cliente; también dice si una cita tiene un cambio de hora pendiente.
 - getMyAgenda: la agenda del usuario COMO BARBERO/EQUIPO (las citas que SUS clientes reservaron con él). Requiere sesión y plan de pago. NO la confundas con getMyAppointments.
 - getMyProfile: nombre, teléfono y email del usuario. Casi nunca: el bloque de sesión ya los trae.
@@ -171,6 +171,8 @@ Propuestas — PREPARAN una acción y devuelven una tarjeta de confirmación; NO
 
 # Reservas y datos del cliente
 - Pa' reservar se necesita: nombre completo y celular de 10 dígitos. Email opcional (sirve pa' la confirmación).
+- Una cita puede incluir VARIOS servicios (ej. corte + barba): pásalos todos en serviceIds, en el orden pedido, sin repetir. El barbero debe ofrecerlos TODOS (listBarbersForService con todos los ids) y la cita ocupa un solo bloque continuo con la suma de duraciones.
+- Precios "Desde": un servicio con precio "desde" tiene un MÍNIMO obligatorio; el precio final se acuerda en persona al terminar. Preséntalo siempre como "desde $X" y NUNCA prometas un total exacto si algún servicio de la cita es "desde" — di "desde $TOTAL".
 - Si el bloque de sesión trae nombre y teléfono del usuario, úsalos directo en proposeBooking; no los preguntes ni llames getMyProfile.
 - Si el bloque de sesión dice "no registrado" en el teléfono, pídelo antes de proponer.
 - Si reservas POR otra persona (equipo a un cliente), pide su nombre y su celular UNA vez; si el celular no tiene 10 dígitos, pídelo completo una sola vez, sin regañar.

--- a/convex/aiAgentHelpers.ts
+++ b/convex/aiAgentHelpers.ts
@@ -25,7 +25,7 @@ const helperPriceFormatter = new Intl.NumberFormat("es-CO", {
 });
 
 /** "Desde $X" for starting-price services; the plain price otherwise. */
-function formatServicePriceLabel(service: Service): string {
+export function formatServicePriceLabel(service: Service): string {
   return service.priceType === "starting"
     ? `Desde ${helperPriceFormatter.format(service.price)}`
     : helperPriceFormatter.format(service.price);

--- a/convex/aiAgentHelpers.ts
+++ b/convex/aiAgentHelpers.ts
@@ -488,30 +488,55 @@ export const assertAppointmentActor = zInternalQuery({
 });
 
 /**
- * Count of future, still-active appointments that a destructive management
- * action would cancel. Lets a propose tool warn the user ("esto cancela N
- * citas") inside the confirmation card before they approve.
+ * Future, still-active appointments a service deletion would touch, split the
+ * same way `services.deleteService` splits them: sole-line citas get
+ * cancelled, multi-line citas only lose the line. Lets the propose tool
+ * disclose both effects in the confirmation card — the AI confirm path runs
+ * the deletion with `force: true`, so this card is the only disclosure.
  */
 export const countImpactedByService = zInternalQuery({
   args: z.object({ serviceId: z.string() }),
   handler: async (ctx, args) => {
+    const serviceId = args.serviceId as Service["_id"];
+    const service = await ctx.db.get(serviceId);
+
+    if (!service) {
+      return { willCancel: 0, willUpdate: 0 };
+    }
+
     const now = Date.now();
-    const impacted = await ctx.db
+    const future = await ctx.db
       .query("appointments")
-      .withIndex("by_serviceId", (q) =>
-        q.eq("serviceId", args.serviceId as Service["_id"]),
+      .withIndex("by_barbershopId_and_date", (q) =>
+        q.eq("barbershopId", service.barbershopId).gte("date", now),
       )
-      .filter((q) =>
-        q.and(
-          q.eq(q.field("deletedAt"), undefined),
-          q.gte(q.field("date"), now),
-        ),
-      )
+      .filter((q) => q.eq(q.field("deletedAt"), undefined))
       .collect();
 
-    return impacted.filter((a) =>
-      ACTIVE_APPOINTMENT_STATUSES.includes(a.status),
-    ).length;
+    let willCancel = 0;
+    let willUpdate = 0;
+
+    for (const appt of future) {
+      if (!ACTIVE_APPOINTMENT_STATUSES.includes(appt.status)) {
+        continue;
+      }
+
+      if (appt.items && appt.items.length > 0) {
+        if (!appt.items.some((line) => line.serviceId === serviceId)) {
+          continue;
+        }
+
+        if (appt.items.length === 1) {
+          willCancel += 1;
+        } else {
+          willUpdate += 1;
+        }
+      } else if (appt.serviceId === serviceId) {
+        willCancel += 1;
+      }
+    }
+
+    return { willCancel, willUpdate };
   },
 });
 

--- a/convex/aiAgentHelpers.ts
+++ b/convex/aiAgentHelpers.ts
@@ -18,6 +18,19 @@ import type {
 import { barbershops } from "./schema";
 import { getProfileByUserId } from "./userProfileData";
 
+const helperPriceFormatter = new Intl.NumberFormat("es-CO", {
+  style: "currency",
+  currency: "COP",
+  maximumFractionDigits: 0,
+});
+
+/** "Desde $X" for starting-price services; the plain price otherwise. */
+function formatServicePriceLabel(service: Service): string {
+  return service.priceType === "starting"
+    ? `Desde ${helperPriceFormatter.format(service.price)}`
+    : helperPriceFormatter.format(service.price);
+}
+
 const ACTIVE_APPOINTMENT_STATUSES: Appointment["status"][] = [
   "pending",
   "confirmed",
@@ -392,6 +405,8 @@ export const getMyBarbershopData = zInternalQuery({
         serviceId: s._id as string,
         name: s.name,
         price: s.price,
+        priceType: s.priceType ?? "fixed",
+        priceFormatted: formatServicePriceLabel(s),
         durationMinutes: s.duration,
       })),
       barbers,

--- a/convex/aiAgentTools.ts
+++ b/convex/aiAgentTools.ts
@@ -1174,12 +1174,10 @@ const proposeManageAppointment = createTool({
       const missing = startingLinesMissingFinal(appt.items ?? []);
 
       if (missing.length > 0) {
+        const names = missing.map((line) => line.name).join(", ");
+
         throw new Error(
-          `La cita incluye servicios con precio "desde" (${missing
-            .map((line) => line.name)
-            .join(
-              ", ",
-            )}). Márcala como completada desde el panel de citas, donde se ingresa el precio final acordado.`,
+          `La cita incluye servicios con precio "desde" (${names}). Márcala como completada desde el panel de citas, donde se ingresa el precio final acordado.`,
         );
       }
     }

--- a/convex/aiAgentTools.ts
+++ b/convex/aiAgentTools.ts
@@ -176,6 +176,18 @@ const manageAppointmentProposal = z.object({
     appointmentId: z.string(),
     status: z.enum(["completed", "no-show", "cancelled"]),
     reason: z.string().optional(),
+    /**
+     * "Desde" lines still missing their agreed final price. The proposal card
+     * renders one input per line and sends the values back as `finalPrices`.
+     */
+    startingLines: z
+      .object({
+        serviceId: z.string(),
+        name: z.string(),
+        minimumPrice: z.number(),
+      })
+      .array()
+      .optional(),
   }),
 });
 
@@ -1167,19 +1179,20 @@ const proposeManageAppointment = createTool({
       throw new Error("Necesito un motivo breve para cancelar la cita.");
     }
 
-    // Completion of "desde"-priced lines needs the agreed final prices, which
-    // the chat card cannot collect — `setStatus` would reject the confirm.
-    if (input.status === "completed") {
-      const missing = startingLinesMissingFinal(appt.items ?? []);
-
-      if (missing.length > 0) {
-        const names = missing.map((line) => line.name).join(", ");
-
-        throw new Error(
-          `La cita incluye servicios con precio "desde" (${names}). Márcala como completada desde el panel de citas, donde se ingresa el precio final acordado.`,
-        );
-      }
-    }
+    // Completing "desde"-priced lines needs the agreed final prices: surface
+    // them on the card, which collects one final price per pending line.
+    const missingFinals =
+      input.status === "completed"
+        ? startingLinesMissingFinal(appt.items ?? [])
+        : [];
+    const startingLines =
+      missingFinals.length > 0
+        ? missingFinals.map((line) => ({
+            serviceId: line.serviceId,
+            name: line.name,
+            minimumPrice: line.price,
+          }))
+        : undefined;
 
     const labels = {
       completed: "completada",
@@ -1187,14 +1200,19 @@ const proposeManageAppointment = createTool({
       cancelled: "cancelada",
     } as const;
 
+    const summary = `Marcar la cita de ${appt.customerName} (${formatDate(appt.date)}) como ${labels[input.status]}.`;
+
     return {
       kind: proposalKind,
       action: "manageAppointment",
-      summary: `Marcar la cita de ${appt.customerName} (${formatDate(appt.date)}) como ${labels[input.status]}.`,
+      summary: startingLines
+        ? `${summary} Ingresa el precio final acordado de cada servicio con precio "desde".`
+        : summary,
       args: {
         appointmentId: appt._id,
         status: input.status,
         reason: input.reason,
+        startingLines,
       },
     };
   },

--- a/convex/aiAgentTools.ts
+++ b/convex/aiAgentTools.ts
@@ -417,7 +417,7 @@ const getAvailability = createTool({
     const slots = (await ctx.runQuery(api.appointments.getAvailableSlots, {
       barbershopId: input.barbershopId as Barbershop["_id"],
       barbershopMemberId: input.barbershopMemberId as BarbershopMember["_id"],
-      serviceId: input.serviceId as Service["_id"],
+      serviceIds: [input.serviceId as Service["_id"]],
       date: dateMs,
     })) as Slot[];
 
@@ -770,7 +770,7 @@ const proposeBooking = createTool({
     const slots = (await ctx.runQuery(api.appointments.getAvailableSlots, {
       barbershopId: shop._id,
       barbershopMemberId: barber._id,
-      serviceId: service._id,
+      serviceIds: [service._id],
       date: dateMs,
     })) as Slot[];
 
@@ -878,7 +878,7 @@ const proposeReschedule = createTool({
     const slots = (await ctx.runQuery(api.appointments.getAvailableSlots, {
       barbershopId: appt.barbershopId,
       barbershopMemberId: appt.barbershopMemberId,
-      serviceId: appt.serviceId,
+      serviceIds: [appt.serviceId],
       date: newDateMs,
     })) as Slot[];
 
@@ -1005,7 +1005,7 @@ const proposeStaffBooking = createTool({
     const slots = (await ctx.runQuery(api.appointments.getAvailableSlots, {
       barbershopId,
       barbershopMemberId: barber._id,
-      serviceId: service._id,
+      serviceIds: [service._id],
       date: dateMs,
     })) as Slot[];
 

--- a/convex/aiAgentTools.ts
+++ b/convex/aiAgentTools.ts
@@ -2,6 +2,8 @@ import { createTool } from "@convex-dev/agent";
 import { z } from "zod";
 
 import { api, internal } from "./_generated/api";
+import { itemsLabel, startingLinesMissingFinal } from "./appointmentItems";
+import { errorMessages } from "./errors";
 import type {
   Appointment,
   Barbershop,
@@ -508,13 +510,17 @@ const getMyAppointments = createTool({
     const sliced = filtered.slice(0, 10);
     const enrichedData = await Promise.all(
       sliced.map(async (appt) => {
-        const [shop, service, members] = await Promise.all([
+        // Snapshot lines are canonical; the live service only labels legacy
+        // rows (a renamed/deleted service must not rewrite past bookings).
+        const [shop, legacyService, members] = await Promise.all([
           ctx.runQuery(internal.aiAgentHelpers.getBarbershop, {
             id: appt.barbershopId,
           }) as Promise<BarbershopDoc | null>,
-          ctx.runQuery(api.services.getById, {
-            id: appt.serviceId,
-          }) as Promise<ServiceDoc | null>,
+          appt.items?.length
+            ? Promise.resolve(null)
+            : (ctx.runQuery(api.services.getById, {
+                id: appt.serviceId,
+              }) as Promise<ServiceDoc | null>),
           ctx.runQuery(internal.aiAgentHelpers.getMembersByBarbershopId, {
             id: appt.barbershopId,
           }) as Promise<BarberWithName[]>,
@@ -527,7 +533,9 @@ const getMyAppointments = createTool({
         return {
           appointmentId: appt._id,
           barbershop: shop?.name ?? "",
-          service: service?.name ?? "",
+          service: appt.items?.length
+            ? itemsLabel(appt.items)
+            : (legacyService?.name ?? ""),
           barber: barber?.name ?? "",
           when: formatDate(appt.date),
           status: appt.status,
@@ -612,7 +620,10 @@ const getMyAgenda = createTool({
 
     const sliced = relevant.slice(0, 10);
 
-    const serviceIds = [...new Set(sliced.map((a) => a.serviceId))];
+    // Live lookups only label legacy rows; item-carrying rows use snapshots.
+    const serviceIds = [
+      ...new Set(sliced.flatMap((a) => (a.items?.length ? [] : [a.serviceId]))),
+    ];
     const serviceDocs = (await Promise.all(
       serviceIds.map((id) => ctx.runQuery(api.services.getById, { id })),
     )) as (ServiceDoc | null)[];
@@ -627,7 +638,9 @@ const getMyAgenda = createTool({
       count: sliced.length,
       appointments: sliced.map((a) => ({
         customerName: a.customerName,
-        service: serviceNames.get(a.serviceId) ?? "",
+        service: a.items?.length
+          ? itemsLabel(a.items)
+          : (serviceNames.get(a.serviceId) ?? ""),
         when: formatDate(a.date),
         status: a.status,
         rescheduleProposedWhen:
@@ -786,6 +799,10 @@ const proposeBooking = createTool({
     notes: z.string().optional(),
   }),
   execute: async (ctx, input): Promise<Proposal> => {
+    if (new Set(input.serviceIds).size !== input.serviceIds.length) {
+      throw new Error(errorMessages.duplicateAppointmentService);
+    }
+
     const dateMs = colombiaDateTimeToMs(input.date, input.time);
 
     const [shop, loadedServices, members] = await Promise.all([
@@ -1046,6 +1063,10 @@ const proposeStaffBooking = createTool({
       );
     }
 
+    if (new Set(input.serviceIds).size !== input.serviceIds.length) {
+      throw new Error(errorMessages.duplicateAppointmentService);
+    }
+
     const dateMs = colombiaDateTimeToMs(input.date, input.time);
     const barbershopId = actor.barbershopId as Barbershop["_id"];
 
@@ -1145,6 +1166,22 @@ const proposeManageAppointment = createTool({
 
     if (input.status === "cancelled" && !input.reason) {
       throw new Error("Necesito un motivo breve para cancelar la cita.");
+    }
+
+    // Completion of "desde"-priced lines needs the agreed final prices, which
+    // the chat card cannot collect — `setStatus` would reject the confirm.
+    if (input.status === "completed") {
+      const missing = startingLinesMissingFinal(appt.items ?? []);
+
+      if (missing.length > 0) {
+        throw new Error(
+          `La cita incluye servicios con precio "desde" (${missing
+            .map((line) => line.name)
+            .join(
+              ", ",
+            )}). Márcala como completada desde el panel de citas, donde se ingresa el precio final acordado.`,
+        );
+      }
     }
 
     const labels = {
@@ -1347,11 +1384,23 @@ const proposeDeleteService = createTool({
     const impacted = (await ctx.runQuery(
       internal.aiAgentHelpers.countImpactedByService,
       { serviceId: service._id },
-    )) as number;
+    )) as { willCancel: number; willUpdate: number };
+
+    const effects: string[] = [];
+
+    if (impacted.willCancel > 0) {
+      effects.push(`cancelará ${impacted.willCancel} cita(s) futura(s)`);
+    }
+
+    if (impacted.willUpdate > 0) {
+      effects.push(
+        `quitará el servicio de ${impacted.willUpdate} cita(s) que tienen más servicios`,
+      );
+    }
 
     const warn =
-      impacted > 0
-        ? ` Esto cancelará ${impacted} cita(s) futura(s) y se avisará a esos clientes.`
+      effects.length > 0
+        ? ` Esto ${effects.join(" y ")}; se avisará a esos clientes.`
         : "";
 
     return {

--- a/convex/aiAgentTools.ts
+++ b/convex/aiAgentTools.ts
@@ -199,6 +199,7 @@ const createServiceProposal = z.object({
     barbershopId: z.string(),
     name: z.string(),
     price: z.number(),
+    priceType: z.enum(["fixed", "starting"]).optional(),
     durationMinutes: z.number(),
   }),
 });
@@ -212,6 +213,7 @@ const updateServiceProposal = z.object({
     serviceId: z.string(),
     name: z.string().optional(),
     price: z.number().optional(),
+    priceType: z.enum(["fixed", "starting"]).optional(),
     durationMinutes: z.number().optional(),
   }),
 });
@@ -892,15 +894,20 @@ const proposeCancellation = createTool({
       ctx.runQuery(internal.aiAgentHelpers.getBarbershop, {
         id: appt.barbershopId,
       }) as Promise<BarbershopDoc | null>,
-      ctx.runQuery(api.services.getById, {
-        id: appt.serviceId,
-      }) as Promise<ServiceDoc | null>,
+      appt.items?.length
+        ? Promise.resolve(null)
+        : (ctx.runQuery(api.services.getById, {
+            id: appt.serviceId,
+          }) as Promise<ServiceDoc | null>),
     ]);
+    const serviceLabel = appt.items?.length
+      ? itemsLabel(appt.items)
+      : (service?.name ?? "servicio");
 
     return {
       kind: proposalKind,
       action: "cancel",
-      summary: `Cancelar tu cita de ${service?.name ?? "servicio"} en ${shop?.name ?? "la barbería"} programada para el ${formatDate(appt.date)}.`,
+      summary: `Cancelar tu cita de ${serviceLabel} en ${shop?.name ?? "la barbería"} programada para el ${formatDate(appt.date)}.`,
       args: {
         appointmentId: appt._id,
         reason: input.reason,
@@ -1256,6 +1263,12 @@ const proposeCreateService = createTool({
       .number()
       .min(1000)
       .describe("Precio en pesos colombianos (COP), p. ej. 25000"),
+    priceType: z
+      .enum(["fixed", "starting"])
+      .optional()
+      .describe(
+        "'starting' si el precio es 'desde' (mínimo); 'fixed' si es exacto",
+      ),
     durationMinutes: z.number().min(5).max(480),
   }),
   execute: async (ctx, input): Promise<Proposal> => {
@@ -1273,11 +1286,12 @@ const proposeCreateService = createTool({
     return {
       kind: proposalKind,
       action: "createService",
-      summary: `Crear el servicio "${input.name}" por ${formatPrice(input.price)} (${input.durationMinutes} min).`,
+      summary: `Crear el servicio "${input.name}" ${input.priceType === "starting" ? "desde" : "por"} ${formatPrice(input.price)} (${input.durationMinutes} min).`,
       args: {
         barbershopId: actor.barbershopId as string,
         name: input.name,
         price: input.price,
+        priceType: input.priceType,
         durationMinutes: input.durationMinutes,
       },
     };
@@ -1286,11 +1300,17 @@ const proposeCreateService = createTool({
 
 const proposeUpdateService = createTool({
   description:
-    "Prepara la edición de un servicio (nombre, precio y/o duración — manda solo lo que cambia). NO lo edita; devuelve una tarjeta de confirmación. Solo dueño o recepcionista. Pásale el serviceId de getMyBarbershop.",
+    "Prepara la edición de un servicio (nombre, precio, tipo de precio y/o duración — manda solo lo que cambia). NO lo edita; devuelve una tarjeta de confirmación. Solo dueño o recepcionista. Pásale el serviceId de getMyBarbershop.",
   inputSchema: z.object({
     serviceId: z.string(),
     name: z.string().min(3).optional(),
     price: z.number().min(1000).optional(),
+    priceType: z
+      .enum(["fixed", "starting"])
+      .optional()
+      .describe(
+        "'starting' si el precio es 'desde' (mínimo); 'fixed' si es exacto",
+      ),
     durationMinutes: z.number().min(5).max(480).optional(),
   }),
   execute: async (ctx, input): Promise<Proposal> => {
@@ -1318,15 +1338,22 @@ const proposeUpdateService = createTool({
     if (
       input.name === undefined &&
       input.price === undefined &&
+      input.priceType === undefined &&
       input.durationMinutes === undefined
     ) {
-      throw new Error("Dime qué quieres cambiar: nombre, precio o duración.");
+      throw new Error(
+        "Dime qué quieres cambiar: nombre, precio, tipo de precio o duración.",
+      );
     }
 
     const parts: string[] = [];
     if (input.name !== undefined) parts.push(`nombre a "${input.name}"`);
     if (input.price !== undefined)
       parts.push(`precio a ${formatPrice(input.price)}`);
+    if (input.priceType !== undefined)
+      parts.push(
+        `tipo de precio a ${input.priceType === "starting" ? '"desde"' : "fijo"}`,
+      );
     if (input.durationMinutes !== undefined)
       parts.push(`duración a ${input.durationMinutes} min`);
 
@@ -1339,6 +1366,7 @@ const proposeUpdateService = createTool({
         serviceId: service._id,
         name: input.name,
         price: input.price,
+        priceType: input.priceType,
         durationMinutes: input.durationMinutes,
       },
     };

--- a/convex/aiAgentTools.ts
+++ b/convex/aiAgentTools.ts
@@ -2,6 +2,7 @@ import { createTool } from "@convex-dev/agent";
 import { z } from "zod";
 
 import { api, internal } from "./_generated/api";
+import { formatServicePriceLabel } from "./aiAgentHelpers";
 import { itemsLabel, startingLinesMissingFinal } from "./appointmentItems";
 import { errorMessages } from "./errors";
 import type {
@@ -302,15 +303,6 @@ const formatDateOnly = (ms: number): string =>
 
 const formatPrice = (cop: number): string => priceFormatter.format(cop);
 
-/** "Desde $X" for starting-price services; the plain price otherwise. */
-const formatServicePrice = (service: {
-  price: number;
-  priceType?: "fixed" | "starting";
-}): string =>
-  service.priceType === "starting"
-    ? `Desde ${priceFormatter.format(service.price)}`
-    : priceFormatter.format(service.price);
-
 /** "Corte $20.000" / "Barba desde $15.000" — per-line proposal detail. */
 const serviceLineLabel = (service: ServiceDoc): string =>
   service.priceType === "starting"
@@ -410,7 +402,7 @@ const getBarbershopDetails = createTool({
         name: s.name,
         price: s.price,
         priceType: s.priceType ?? "fixed",
-        priceFormatted: formatServicePrice(s),
+        priceFormatted: formatServicePriceLabel(s),
         durationMinutes: s.duration,
       })),
     };

--- a/convex/aiAgentTools.ts
+++ b/convex/aiAgentTools.ts
@@ -76,6 +76,8 @@ type MyBarbershopData =
         serviceId: string;
         name: string;
         price: number;
+        priceType: "fixed" | "starting";
+        priceFormatted: string;
         durationMinutes: number;
       }>;
       barbers: Array<{
@@ -114,7 +116,7 @@ const bookProposal = z.object({
   summary: z.string(),
   args: z.object({
     barbershopId: z.string(),
-    serviceId: z.string(),
+    serviceIds: z.string().array(),
     barbershopMemberId: z.string(),
     date: z.number(),
     customerName: z.string(),
@@ -152,7 +154,7 @@ const staffBookProposal = z.object({
   summary: z.string(),
   args: z.object({
     barbershopId: z.string(),
-    serviceId: z.string(),
+    serviceIds: z.string().array(),
     barbershopMemberId: z.string(),
     date: z.number(),
     customerName: z.string(),
@@ -298,6 +300,40 @@ const formatDateOnly = (ms: number): string =>
 
 const formatPrice = (cop: number): string => priceFormatter.format(cop);
 
+/** "Desde $X" for starting-price services; the plain price otherwise. */
+const formatServicePrice = (service: {
+  price: number;
+  priceType?: "fixed" | "starting";
+}): string =>
+  service.priceType === "starting"
+    ? `Desde ${priceFormatter.format(service.price)}`
+    : priceFormatter.format(service.price);
+
+/** "Corte $20.000" / "Barba desde $15.000" — per-line proposal detail. */
+const serviceLineLabel = (service: ServiceDoc): string =>
+  service.priceType === "starting"
+    ? `${service.name} desde ${formatPrice(service.price)}`
+    : `${service.name} ${formatPrice(service.price)}`;
+
+/** Joined names + total ("desde"-prefixed when any line is starting). */
+const servicesSummary = (selected: ServiceDoc[]) => {
+  const total = selected.reduce((sum, service) => sum + service.price, 0);
+  const hasStarting = selected.some(
+    (service) => service.priceType === "starting",
+  );
+
+  return {
+    label: selected.map((service) => service.name).join(" + "),
+    totalLabel: hasStarting
+      ? `desde ${formatPrice(total)}`
+      : formatPrice(total),
+    detail:
+      selected.length > 1
+        ? ` (${selected.map(serviceLineLabel).join(" + ")})`
+        : "",
+  };
+};
+
 // ---------------------------------------------------------------------------
 // READ TOOLS
 // ---------------------------------------------------------------------------
@@ -371,7 +407,8 @@ const getBarbershopDetails = createTool({
         serviceId: s._id,
         name: s.name,
         price: s.price,
-        priceFormatted: formatPrice(s.price),
+        priceType: s.priceType ?? "fixed",
+        priceFormatted: formatServicePrice(s),
         durationMinutes: s.duration,
       })),
     };
@@ -380,16 +417,18 @@ const getBarbershopDetails = createTool({
 
 const listBarbersForService = createTool({
   description:
-    "Lista los barberos que ofrecen un servicio específico. Necesario antes de proponer una reserva: el `barbershopMemberId` se obtiene aquí.",
+    "Lista los barberos que ofrecen TODOS los servicios seleccionados. Necesario antes de proponer una reserva: el `barbershopMemberId` se obtiene aquí.",
   inputSchema: z.object({
-    serviceId: z
+    serviceIds: z
       .string()
-      .describe("Id del servicio (de `getBarbershopDetails`)"),
+      .array()
+      .min(1)
+      .describe("Ids de los servicios (de `getBarbershopDetails`)"),
   }),
   execute: async (ctx, input) => {
     const barbers = (await ctx.runQuery(
-      api.barbershopMemberServices.getBarbersForService,
-      { id: input.serviceId as Service["_id"] },
+      api.barbershopMemberServices.getBarbersForServices,
+      { serviceIds: input.serviceIds as Service["_id"][] },
     )) as (BarberWithName | null)[];
 
     return barbers.flatMap((b) =>
@@ -400,7 +439,7 @@ const listBarbersForService = createTool({
 
 const getAvailability = createTool({
   description:
-    "Devuelve los horarios disponibles (en formato HH:MM) para reservar con un barbero, en una fecha y un servicio determinados. Úsala SIEMPRE antes de proponer una reserva.",
+    "Devuelve los horarios disponibles (en formato HH:MM) para reservar con un barbero, en una fecha y uno o varios servicios (la cita ocupa la suma de sus duraciones). Úsala SIEMPRE antes de proponer una reserva.",
   inputSchema: z.object({
     barbershopId: z.string().describe("Id interno de la barbería"),
     barbershopMemberId: z
@@ -408,7 +447,7 @@ const getAvailability = createTool({
       .describe(
         "Id del barbero (de `listBarbersForService` o `getMyBarbershop`)",
       ),
-    serviceId: z.string().describe("Id del servicio"),
+    serviceIds: z.string().array().min(1).describe("Ids de los servicios"),
     date: dateField.describe(DATE_DESC),
   }),
   execute: async (ctx, input) => {
@@ -417,7 +456,7 @@ const getAvailability = createTool({
     const slots = (await ctx.runQuery(api.appointments.getAvailableSlots, {
       barbershopId: input.barbershopId as Barbershop["_id"],
       barbershopMemberId: input.barbershopMemberId as BarbershopMember["_id"],
-      serviceIds: [input.serviceId as Service["_id"]],
+      serviceIds: input.serviceIds as Service["_id"][],
       date: dateMs,
     })) as Slot[];
 
@@ -726,7 +765,11 @@ const proposeBooking = createTool({
     "Prepara una propuesta de reserva. NO crea la cita: devuelve un resumen y los argumentos para que el usuario confirme en la interfaz. SIEMPRE valida disponibilidad con `getAvailability` antes de llamar a esta herramienta.",
   inputSchema: z.object({
     barbershopId: z.string().describe("Id interno de la barbería"),
-    serviceId: z.string().describe("Id del servicio"),
+    serviceIds: z
+      .string()
+      .array()
+      .min(1)
+      .describe("Ids de los servicios (uno o varios, en el orden pedido)"),
     barbershopMemberId: z.string().describe("Id del barbero"),
     date: dateField.describe(DATE_DESC),
     time: timeField.describe(TIME_DESC),
@@ -745,20 +788,29 @@ const proposeBooking = createTool({
   execute: async (ctx, input): Promise<Proposal> => {
     const dateMs = colombiaDateTimeToMs(input.date, input.time);
 
-    const [shop, service, members] = await Promise.all([
+    const [shop, loadedServices, members] = await Promise.all([
       ctx.runQuery(internal.aiAgentHelpers.getBarbershop, {
         id: input.barbershopId,
       }) as Promise<BarbershopDoc | null>,
-      ctx.runQuery(api.services.getById, {
-        id: input.serviceId as Service["_id"],
-      }) as Promise<ServiceDoc | null>,
+      ctx.runQuery(api.services.getByIds, {
+        serviceIds: input.serviceIds.map((serviceId) => ({
+          id: serviceId as Service["_id"],
+        })),
+      }) as Promise<(ServiceDoc | null)[]>,
       ctx.runQuery(internal.aiAgentHelpers.getMembersByBarbershopId, {
         id: input.barbershopId as Barbershop["_id"],
       }) as Promise<BarberWithName[]>,
     ]);
 
     if (!shop) throw new Error("Esa barbería no existe.");
-    if (!service) throw new Error("Ese servicio no existe.");
+
+    const selectedServices = loadedServices.filter(
+      (service): service is ServiceDoc => !!service,
+    );
+
+    if (selectedServices.length !== input.serviceIds.length) {
+      throw new Error("Alguno de esos servicios no existe.");
+    }
 
     const barber = members.find(
       (m: BarberWithName) =>
@@ -770,7 +822,7 @@ const proposeBooking = createTool({
     const slots = (await ctx.runQuery(api.appointments.getAvailableSlots, {
       barbershopId: shop._id,
       barbershopMemberId: barber._id,
-      serviceIds: [service._id],
+      serviceIds: selectedServices.map((service) => service._id),
       date: dateMs,
     })) as Slot[];
 
@@ -782,13 +834,15 @@ const proposeBooking = createTool({
       );
     }
 
+    const summary = servicesSummary(selectedServices);
+
     return {
       kind: proposalKind,
       action: "book",
-      summary: `Reservar ${service.name} con ${barber.name} en ${shop.name} el ${formatDate(dateMs)} por ${formatPrice(service.price)}.`,
+      summary: `Reservar ${summary.label} con ${barber.name} en ${shop.name} el ${formatDate(dateMs)} por ${summary.totalLabel}${summary.detail}.`,
       args: {
         barbershopId: shop._id,
-        serviceId: service._id,
+        serviceIds: selectedServices.map((service) => service._id),
         barbershopMemberId: barber._id,
         date: dateMs,
         customerName: input.customerName,
@@ -875,10 +929,16 @@ const proposeReschedule = createTool({
       throw new Error("La nueva fecha debe ser en el futuro.");
     }
 
+    // Snapshot lines drive the width (durationMinutes) so the re-check works
+    // even if a line's service was edited or deleted after booking.
     const slots = (await ctx.runQuery(api.appointments.getAvailableSlots, {
       barbershopId: appt.barbershopId,
       barbershopMemberId: appt.barbershopMemberId,
-      serviceIds: [appt.serviceId],
+      serviceIds: appt.items?.map((line) => line.serviceId) ?? [appt.serviceId],
+      durationMinutes: appt.items?.reduce(
+        (total, line) => total + line.duration,
+        0,
+      ),
       date: newDateMs,
     })) as Slot[];
 
@@ -941,7 +1001,11 @@ const proposeStaffBooking = createTool({
   description:
     "Prepara una reserva que un miembro del equipo (barbero o recepcionista) hace POR un cliente de la barbería, asignándola a un barbero. NO crea la cita; devuelve una tarjeta de confirmación. Valida disponibilidad con getAvailability antes. Si quien escribe es barbero y atenderá él mismo, usa su propio `myMemberId` como barbershopMemberId. Requiere sesión y un plan que permita crear citas por clientes.",
   inputSchema: z.object({
-    serviceId: z.string().describe("Id del servicio (de getMyBarbershop)"),
+    serviceIds: z
+      .string()
+      .array()
+      .min(1)
+      .describe("Ids de los servicios (de getMyBarbershop, uno o varios)"),
     barbershopMemberId: z
       .string()
       .describe("Id del barbero que atenderá (de getMyBarbershop)"),
@@ -985,16 +1049,24 @@ const proposeStaffBooking = createTool({
     const dateMs = colombiaDateTimeToMs(input.date, input.time);
     const barbershopId = actor.barbershopId as Barbershop["_id"];
 
-    const [service, members] = await Promise.all([
-      ctx.runQuery(api.services.getById, {
-        id: input.serviceId as Service["_id"],
-      }) as Promise<ServiceDoc | null>,
+    const [loadedServices, members] = await Promise.all([
+      ctx.runQuery(api.services.getByIds, {
+        serviceIds: input.serviceIds.map((serviceId) => ({
+          id: serviceId as Service["_id"],
+        })),
+      }) as Promise<(ServiceDoc | null)[]>,
       ctx.runQuery(internal.aiAgentHelpers.getMembersByBarbershopId, {
         id: barbershopId,
       }) as Promise<BarberWithName[]>,
     ]);
 
-    if (!service) throw new Error("Ese servicio no existe.");
+    const selectedServices = loadedServices.filter(
+      (service): service is ServiceDoc => !!service,
+    );
+
+    if (selectedServices.length !== input.serviceIds.length) {
+      throw new Error("Alguno de esos servicios no existe.");
+    }
 
     const barber = members.find(
       (m) => m._id === (input.barbershopMemberId as BarbershopMember["_id"]),
@@ -1005,7 +1077,7 @@ const proposeStaffBooking = createTool({
     const slots = (await ctx.runQuery(api.appointments.getAvailableSlots, {
       barbershopId,
       barbershopMemberId: barber._id,
-      serviceIds: [service._id],
+      serviceIds: selectedServices.map((service) => service._id),
       date: dateMs,
     })) as Slot[];
 
@@ -1017,13 +1089,15 @@ const proposeStaffBooking = createTool({
       );
     }
 
+    const summary = servicesSummary(selectedServices);
+
     return {
       kind: proposalKind,
       action: "staffBook",
-      summary: `Agendar ${service.name} para ${input.customerName} con ${barber.name} el ${formatDate(dateMs)} (${formatPrice(service.price)}).`,
+      summary: `Agendar ${summary.label} para ${input.customerName} con ${barber.name} el ${formatDate(dateMs)} (${summary.totalLabel}${summary.detail}).`,
       args: {
         barbershopId: barbershopId as string,
-        serviceId: service._id,
+        serviceIds: selectedServices.map((service) => service._id),
         barbershopMemberId: barber._id,
         date: dateMs,
         customerName: input.customerName,

--- a/convex/aiChat.ts
+++ b/convex/aiChat.ts
@@ -216,7 +216,9 @@ const scheduleDayArg = z.object({
 
 const bookArgs = z.object({
   barbershopId: z.string(),
-  serviceId: z.string(),
+  /** Pre-deploy proposals carry a single `serviceId`; new ones `serviceIds`. */
+  serviceId: z.string().optional(),
+  serviceIds: z.string().array().optional(),
   barbershopMemberId: z.string(),
   date: z.number(),
   customerName: z.string(),
@@ -301,6 +303,16 @@ const confirmActionArgs = z.discriminatedUnion("action", [
   }),
 ]);
 
+/** Tolerates proposals minted before the multi-service deploy. */
+const bookServiceIds = (args: {
+  serviceIds?: string[];
+  serviceId?: string;
+}): Service["_id"][] => {
+  const ids = args.serviceIds ?? (args.serviceId ? [args.serviceId] : []);
+
+  return ids as Service["_id"][];
+};
+
 const requireAuthed = (isAnon: boolean) => {
   if (isAnon) {
     throw new ConvexError(
@@ -329,7 +341,7 @@ export const confirmPendingAction = zAction({
         await ctx.runMutation(internal.appointments.agentBook, {
           userId: callerId,
           barbershopId: a.barbershopId as Barbershop["_id"],
-          serviceId: a.serviceId as Service["_id"],
+          serviceIds: bookServiceIds(a),
           barbershopMemberId: a.barbershopMemberId as BarbershopMember["_id"],
           date: a.date,
           customerName: a.customerName,
@@ -348,7 +360,7 @@ export const confirmPendingAction = zAction({
         await ctx.runMutation(api.appointments.create, {
           appointment: {
             barbershopId: a.barbershopId as Barbershop["_id"],
-            serviceId: a.serviceId as Service["_id"],
+            serviceIds: bookServiceIds(a),
             barbershopMemberId: a.barbershopMemberId as BarbershopMember["_id"],
             date: a.date,
             customerName: a.customerName,

--- a/convex/aiChat.ts
+++ b/convex/aiChat.ts
@@ -247,6 +247,14 @@ const confirmActionArgs = z.discriminatedUnion("action", [
       appointmentId: z.string(),
       status: z.enum(["completed", "no-show", "cancelled"]),
       reason: z.string().optional(),
+      /** Final agreed price per "desde" line, collected on the proposal card. */
+      finalPrices: z
+        .object({
+          serviceId: z.string(),
+          finalPrice: z.number(),
+        })
+        .array()
+        .optional(),
     }),
   }),
   z.object({
@@ -424,9 +432,15 @@ export const confirmPendingAction = zAction({
           });
           summary = "Listo, cancelé la cita y el cliente queda avisado.";
         } else {
+          // `setStatus` re-validates the finals (required per "desde" line,
+          // never below the minimum), so forged card args can't undercut it.
           await ctx.runMutation(api.appointments.setStatus, {
             appointment: { id: a.appointmentId as Appointment["_id"] },
             status: a.status,
+            finalPrices: a.finalPrices?.map((entry) => ({
+              serviceId: entry.serviceId as Service["_id"],
+              finalPrice: entry.finalPrice,
+            })),
           });
           summary =
             a.status === "completed"

--- a/convex/aiChat.ts
+++ b/convex/aiChat.ts
@@ -263,6 +263,7 @@ const confirmActionArgs = z.discriminatedUnion("action", [
       barbershopId: z.string(),
       name: z.string(),
       price: z.number(),
+      priceType: z.enum(["fixed", "starting"]).optional(),
       durationMinutes: z.number(),
     }),
   }),
@@ -273,6 +274,7 @@ const confirmActionArgs = z.discriminatedUnion("action", [
       serviceId: z.string(),
       name: z.string().optional(),
       price: z.number().optional(),
+      priceType: z.enum(["fixed", "starting"]).optional(),
       durationMinutes: z.number().optional(),
     }),
   }),
@@ -457,6 +459,7 @@ export const confirmPendingAction = zAction({
         await ctx.runMutation(api.services.create, {
           name: a.name,
           price: a.price,
+          priceType: a.priceType,
           duration: a.durationMinutes,
           barbershopId: a.barbershopId as Barbershop["_id"],
         });
@@ -469,11 +472,13 @@ export const confirmPendingAction = zAction({
         const data: {
           name?: string;
           price?: number;
+          priceType?: "fixed" | "starting";
           duration?: number;
           barbershopId: Barbershop["_id"];
         } = { barbershopId: a.barbershopId as Barbershop["_id"] };
         if (a.name !== undefined) data.name = a.name;
         if (a.price !== undefined) data.price = a.price;
+        if (a.priceType !== undefined) data.priceType = a.priceType;
         if (a.durationMinutes !== undefined) data.duration = a.durationMinutes;
         await ctx.runMutation(api.services.update, {
           id: a.serviceId as Service["_id"],

--- a/convex/aiRag.ts
+++ b/convex/aiRag.ts
@@ -143,6 +143,7 @@ export const getShopKnowledgeData = zInternalQuery({
       services: services.map((s) => ({
         name: s.name,
         price: s.price,
+        priceType: s.priceType ?? "fixed",
         durationMinutes: s.duration,
       })),
     };
@@ -186,7 +187,7 @@ export const reindexShopKnowledge = zInternalAction({
       ? data.services
           .map(
             (s) =>
-              `${s.name}: $${s.price.toLocaleString("es-CO")} (${s.durationMinutes} min)`,
+              `${s.name}: ${s.priceType === "starting" ? "desde " : ""}$${s.price.toLocaleString("es-CO")} (${s.durationMinutes} min)`,
           )
           .join("; ")
       : "Sin servicios registrados todavía.";

--- a/convex/appointmentItems.ts
+++ b/convex/appointmentItems.ts
@@ -1,0 +1,117 @@
+/**
+ * Single source of truth for appointment line-item math.
+ *
+ * `items` is canonical on new bookings; legacy rows (pre-backfill) synthesize
+ * a single line here so every consumer reads one shape. Overlap/availability
+ * widths for EXISTING rows go through `conflictDurationMinutes`, which keeps
+ * the historical `liveService?.duration ?? 0` chain bit-for-bit identical for
+ * legacy rows.
+ */
+
+import type { MutationCtx, QueryCtx } from "./_generated/server";
+import type { Appointment, AppointmentItem, Service } from "./schema";
+
+const FALLBACK_NAME = "Servicio";
+const FALLBACK_DURATION = 30;
+
+/** Booking-time snapshot of the selected services, in selection order. */
+export function buildItems(services: Service[]): AppointmentItem[] {
+  return services.map((service) => ({
+    serviceId: service._id,
+    name: service.name,
+    price: service.price,
+    priceType: service.priceType ?? "fixed",
+    duration: service.duration,
+  }));
+}
+
+/**
+ * `items` ?? a synthesized single legacy line. Completed rows prefer the
+ * completion-time snapshot (`completedServicePrice/Name`) so analytics keep
+ * matching; otherwise the live service; otherwise "Servicio" / 0 / 30.
+ */
+export function normalizeItems(
+  appointment: Appointment,
+  liveService: Service | null | undefined,
+): AppointmentItem[] {
+  if (appointment.items && appointment.items.length > 0) {
+    return appointment.items;
+  }
+
+  const isCompleted = appointment.status === "completed";
+  const name =
+    (isCompleted ? appointment.completedServiceName : undefined) ??
+    liveService?.name ??
+    FALLBACK_NAME;
+  const price =
+    (isCompleted ? appointment.completedServicePrice : undefined) ??
+    liveService?.price ??
+    0;
+
+  return [
+    {
+      serviceId: appointment.serviceId,
+      name,
+      price,
+      priceType: "fixed",
+      duration: liveService?.duration ?? FALLBACK_DURATION,
+    },
+  ];
+}
+
+/** Normalized items, loading the legacy row's live service when needed. */
+export async function getAppointmentItems(
+  ctx: QueryCtx | MutationCtx,
+  appointment: Appointment,
+): Promise<AppointmentItem[]> {
+  if (appointment.items && appointment.items.length > 0) {
+    return appointment.items;
+  }
+
+  const liveService = await ctx.db.get(appointment.serviceId);
+
+  return normalizeItems(appointment, liveService);
+}
+
+export function itemsTotalDuration(items: AppointmentItem[]): number {
+  return items.reduce((total, item) => total + item.duration, 0);
+}
+
+/** Σ(finalPrice ?? price) — the appointment's effective total. */
+export function itemsTotal(items: AppointmentItem[]): number {
+  return items.reduce(
+    (total, item) => total + (item.finalPrice ?? item.price),
+    0,
+  );
+}
+
+/** Joined display name: "Corte + Barba". */
+export function itemsLabel(items: AppointmentItem[]): string {
+  return items.map((item) => item.name).join(" + ");
+}
+
+/** Starting-priced lines that still need a final price to complete. */
+export function startingLinesMissingFinal(
+  items: AppointmentItem[],
+): AppointmentItem[] {
+  return items.filter(
+    (item) => item.priceType === "starting" && item.finalPrice === undefined,
+  );
+}
+
+/**
+ * Overlap/availability width for an EXISTING appointment. Kept separate from
+ * `itemsTotalDuration` on purpose: legacy rows (no items) must reproduce
+ * today's exact `liveService?.duration ?? 0` chain so pre-backfill conflict
+ * math never shifts.
+ */
+export function conflictDurationMinutes(
+  appointment: Appointment,
+  lookup: (serviceId: Service["_id"]) => Service | null | undefined,
+): number {
+  if (appointment.items && appointment.items.length > 0) {
+    return itemsTotalDuration(appointment.items);
+  }
+
+  return lookup(appointment.serviceId)?.duration ?? 0;
+}

--- a/convex/appointments.ts
+++ b/convex/appointments.ts
@@ -17,6 +17,14 @@ import type { MutationCtx } from "./_generated/server";
 import { assertCanCreateStaffAppointment } from "./acl";
 import { track } from "./analytics";
 import {
+  buildItems,
+  conflictDurationMinutes,
+  getAppointmentItems,
+  itemsLabel,
+  itemsTotal,
+  itemsTotalDuration,
+} from "./appointmentItems";
+import {
   assertCanMutateAppointment,
   assertShopRole,
   getBarbershopMemberByUserId,
@@ -31,7 +39,7 @@ import {
   reserveForAppointment,
 } from "./inventory";
 import { rateLimitOrThrow } from "./ratelimit";
-import type { Appointment, UserProfileData } from "./schema";
+import type { Appointment, Service, UserProfileData } from "./schema";
 import {
   appointments,
   barbershopMembers,
@@ -62,7 +70,9 @@ const dateTimeFormatter = new Intl.DateTimeFormat("es-CO", {
 const createAppointmentArgs = z.object({
   appointment: z.object({
     barbershopId: barbershops.tools.id.shape.id,
-    serviceId: services.tools.id.shape.id,
+    serviceIds: services.tools.id.shape.id
+      .array()
+      .min(1, "Selecciona al menos un servicio"),
     barbershopMemberId: barbershopMembers.tools.id.shape.id,
     date: z.number(),
     contactPhone: z.string(),
@@ -114,8 +124,16 @@ export const create = zAuthMutation({
       await assertCanCreateStaffAppointment(ctx, appointment.barbershopId);
     }
 
-    const [service, barber] = await Promise.all([
-      ctx.db.get(appointment.serviceId),
+    if (
+      new Set(appointment.serviceIds).size !== appointment.serviceIds.length
+    ) {
+      throw new ConvexError(errorMessages.duplicateAppointmentService);
+    }
+
+    const [loadedServices, barber] = await Promise.all([
+      Promise.all(
+        appointment.serviceIds.map((serviceId) => ctx.db.get(serviceId)),
+      ),
       ctx.db.get(appointment.barbershopMemberId),
     ]);
 
@@ -131,13 +149,22 @@ export const create = zAuthMutation({
       throw new ConvexError(errorMessages.notFound("barbero"));
     }
 
-    if (!service) {
-      throw new ConvexError(errorMessages.notFound("servicio"));
+    const selectedServices: Service[] = [];
+
+    for (const service of loadedServices) {
+      if (!service) {
+        throw new ConvexError(errorMessages.notFound("servicio"));
+      }
+
+      if (service.barbershopId !== appointment.barbershopId) {
+        throw new ConvexError(errorMessages.unauthorized);
+      }
+
+      selectedServices.push(service);
     }
 
-    if (service.barbershopId !== appointment.barbershopId) {
-      throw new ConvexError(errorMessages.unauthorized);
-    }
+    const items = buildItems(selectedServices);
+    const totalDuration = itemsTotalDuration(items);
 
     const barberProfile = await ctx.db.get(barber.userProfileDataId);
     let customerProfile: UserProfileData | null = null;
@@ -150,7 +177,7 @@ export const create = zAuthMutation({
       throw new ConvexError(errorMessages.notFound("perfil de barbero"));
     }
 
-    const endsAt = appointment.date + service.duration * MINUTE_MS;
+    const endsAt = appointment.date + totalDuration * MINUTE_MS;
 
     const startOfDay = new Date(appointment.date);
     startOfDay.setHours(0, 0, 0, 0);
@@ -180,14 +207,17 @@ export const create = zAuthMutation({
       )
       .collect();
 
+    // Legacy rows (no items) still size their width off the live service.
     const apptServices = await Promise.all(
-      candidates.map((appt) => ctx.db.get(appt.serviceId)),
+      candidates.map((appt) =>
+        appt.items && appt.items.length > 0 ? null : ctx.db.get(appt.serviceId),
+      ),
     );
 
     for (let i = 0; i < candidates.length; i++) {
       const appt = candidates[i];
-      const apptService = apptServices[i];
-      const apptEnd = appt.date + (apptService?.duration ?? 0) * MINUTE_MS;
+      const width = conflictDurationMinutes(appt, () => apptServices[i]);
+      const apptEnd = appt.date + width * MINUTE_MS;
       const overlaps = appt.date < endsAt && apptEnd > appointment.date;
 
       if (overlaps) {
@@ -218,7 +248,7 @@ export const create = zAuthMutation({
       throw new ConvexError(errorMessages.barbershopClosedOnSelectedDay);
     }
 
-    const endAt = appointment.date + service.duration * MINUTE_MS;
+    const endAt = appointment.date + totalDuration * MINUTE_MS;
 
     if (
       !withinOpenHours(
@@ -245,8 +275,11 @@ export const create = zAuthMutation({
     const appointmentUserId = isStaffCreatingAppointment
       ? (customerProfile?.userId ?? "user_does_not_exist")
       : userId;
-    const { isStaffCreated: _isStaffCreated, ...withoutIsStaffCreated } =
-      appointment;
+    const {
+      isStaffCreated: _isStaffCreated,
+      serviceIds: _serviceIds,
+      ...withoutIsStaffCreated
+    } = appointment;
 
     // Resolve creator member ID for staff-created appointments
     let createdByMemberId: typeof appointment.barbershopMemberId | undefined;
@@ -266,13 +299,15 @@ export const create = zAuthMutation({
       userId: appointmentUserId,
       status: "confirmed",
       createdBy: createdByMemberId,
+      serviceId: items[0].serviceId,
+      items,
     });
 
-    // Reserve the service's inventory recipe (never throws, plan-gated no-op).
+    // Reserve every line's inventory recipe (never throws, plan-gated no-op).
     await reserveForAppointment(ctx, {
       _id: appointmentId,
       barbershopId: appointment.barbershopId,
-      serviceId: appointment.serviceId,
+      serviceIds: appointment.serviceIds,
       userId: appointmentUserId,
     });
 
@@ -336,10 +371,12 @@ export const create = zAuthMutation({
         barbershopId: appointment.barbershopId,
         source: "web",
         isStaffCreated: isStaffCreatingAppointment,
-        serviceId: appointment.serviceId,
-        serviceName: service.name,
-        servicePrice: service.price,
-        durationMinutes: service.duration,
+        serviceId: items[0].serviceId,
+        serviceIds: appointment.serviceIds,
+        itemCount: items.length,
+        serviceName: itemsLabel(items),
+        servicePrice: itemsTotal(items),
+        durationMinutes: totalDuration,
         barberId: appointment.barbershopMemberId,
         customerType: contactEmail ? "registered" : "anonymous",
       },
@@ -516,8 +553,15 @@ export const setStatus = zAuthMutation({
           pastReminderNotificationId: undefined,
         });
 
-        // Release the recipe holds and consume the stock the service used.
-        await consumeForAppointment(ctx, appt);
+        // Release the recipe holds and consume the stock the services used.
+        const consumedItems = await getAppointmentItems(ctx, appt);
+
+        await consumeForAppointment(ctx, {
+          _id: appointmentId,
+          barbershopId: appt.barbershopId,
+          userId: appt.userId,
+          serviceIds: consumedItems.map((item) => item.serviceId),
+        });
 
         await ctx.runMutation(
           internal.barbershopMetadata.incrementCompletedAppointments,
@@ -933,16 +977,12 @@ export const answerRescheduleRequest = zAuthMutation({
         return;
       }
 
-      const service = await ctx.db.get(appt.serviceId);
-
-      if (!service) {
-        return;
-      }
+      const items = await getAppointmentItems(ctx, appt);
 
       const overlap = await ctx.runQuery(internal.appointments.overlaps, {
         appointment: args.appointment,
         date: appt.proposedDate,
-        endAt: appt.proposedDate + service.duration * MINUTE_MS,
+        endAt: appt.proposedDate + itemsTotalDuration(items) * MINUTE_MS,
       });
 
       if (overlap) {
@@ -1089,12 +1129,6 @@ export const overlaps = zInternalQuery({
       return;
     }
 
-    const service = await ctx.db.get(appointment.serviceId);
-
-    if (!service) {
-      return;
-    }
-
     const startOfDay = new Date(args.date);
     startOfDay.setHours(0, 0, 0, 0);
     const endOfDay = new Date(startOfDay);
@@ -1125,13 +1159,15 @@ export const overlaps = zInternalQuery({
     const activeCandidates = candidates.filter((appt) => !appt.deletedAt);
 
     const services = await Promise.all(
-      activeCandidates.map((appt) => ctx.db.get(appt.serviceId)),
+      activeCandidates.map((appt) =>
+        appt.items && appt.items.length > 0 ? null : ctx.db.get(appt.serviceId),
+      ),
     );
 
     for (let i = 0; i < activeCandidates.length; i++) {
       const appt = activeCandidates[i];
-      const svc = services[i];
-      const apptEnd = appt.date + (svc?.duration ?? 0) * MINUTE_MS;
+      const width = conflictDurationMinutes(appt, () => services[i]);
+      const apptEnd = appt.date + width * MINUTE_MS;
       const overlaps = appt.date < args.endAt && apptEnd > args.date;
       if (overlaps) return appt;
     }
@@ -1147,7 +1183,7 @@ export const overlaps = zInternalQuery({
 const SLOT_INTERVAL = 30; // minutes
 
 /**
- * Returns available 30-minute time slots for a given barber + date + service.
+ * Returns available 30-minute time slots for a given barber + date + services.
  *
  * Logic:
  * 1. Get effective schedule for the barber (custom or inherited from barbershop).
@@ -1162,14 +1198,35 @@ export const getAvailableSlots = zQuery({
   args: z.object({
     barbershopId: barbershops.tools.id.shape.id,
     barbershopMemberId: barbershopMembers.tools.id.shape.id,
-    serviceId: services.tools.id.shape.id,
+    serviceIds: services.tools.id.shape.id.array(),
     /** Midnight timestamp of the selected date (any time on that day works). */
     date: z.number(),
+    /**
+     * Snapshot width override (agent reschedule re-check) — skips the live
+     * service lookup so lines whose services were deleted can still move.
+     */
+    durationMinutes: z.number().optional(),
   }),
   handler: async (ctx, args) => {
-    const service = await ctx.db.get(args.serviceId);
+    // Requested width = Σ live durations, or the snapshot override.
+    let serviceDuration = args.durationMinutes ?? 0;
 
-    if (!service) {
+    if (args.durationMinutes === undefined) {
+      const loadedServices = await Promise.all(
+        args.serviceIds.map((serviceId) => ctx.db.get(serviceId)),
+      );
+
+      if (loadedServices.some((service) => !service)) {
+        return [];
+      }
+
+      serviceDuration = loadedServices.reduce(
+        (total, service) => total + (service?.duration ?? 0),
+        0,
+      );
+    }
+
+    if (serviceDuration <= 0) {
       return [];
     }
 
@@ -1207,8 +1264,6 @@ export const getAvailableSlots = zQuery({
       lunchEndMin !== null &&
       !Number.isNaN(lunchStartMin) &&
       !Number.isNaN(lunchEndMin);
-
-    const serviceDuration = service.duration; // in minutes
 
     // Generate candidate slots
     const slots: Array<{ time: string; minutes: number }> = [];
@@ -1277,8 +1332,9 @@ export const getAvailableSlots = zQuery({
     const occupied: Array<{ start: number; end: number }> = [];
 
     for (const appt of existingAppointments) {
-      const apptService = serviceMap.get(appt.serviceId.toString());
-      const apptDuration = apptService?.duration ?? 0;
+      const apptDuration = conflictDurationMinutes(appt, (serviceId) =>
+        serviceMap.get(serviceId.toString()),
+      );
       const apptStartMin = minutesOfDay(appt.date);
       const apptEndMin = apptStartMin + apptDuration;
       occupied.push({ start: apptStartMin, end: apptEndMin });
@@ -1312,7 +1368,9 @@ export const agentBook = zInternalMutation({
   args: z.object({
     userId: z.string(),
     barbershopId: barbershops.tools.id.shape.id,
-    serviceId: services.tools.id.shape.id,
+    serviceIds: services.tools.id.shape.id
+      .array()
+      .min(1, "Selecciona al menos un servicio"),
     barbershopMemberId: barbershopMembers.tools.id.shape.id,
     date: z.number(),
     customerName: z.string(),
@@ -1321,25 +1379,41 @@ export const agentBook = zInternalMutation({
     notes: z.string().optional(),
   }),
   handler: async (ctx, args) => {
-    const [service, barber, barbershop] = await Promise.all([
-      ctx.db.get(args.serviceId),
+    if (new Set(args.serviceIds).size !== args.serviceIds.length) {
+      throw new ConvexError(errorMessages.duplicateAppointmentService);
+    }
+
+    const [loadedServices, barber, barbershop] = await Promise.all([
+      Promise.all(args.serviceIds.map((serviceId) => ctx.db.get(serviceId))),
       ctx.db.get(args.barbershopMemberId),
       ctx.db.get(args.barbershopId),
     ]);
 
     if (!barber) throw new ConvexError(errorMessages.notFound("barbero"));
-    if (!service) throw new ConvexError(errorMessages.notFound("servicio"));
     if (!barbershop) throw new ConvexError(errorMessages.notFound("barbería"));
     if (barber.barbershopId !== args.barbershopId)
       throw new ConvexError(errorMessages.unauthorized);
     if (!barber.userProfileDataId)
       throw new ConvexError(errorMessages.notFound("barbero"));
 
+    const selectedServices: Service[] = [];
+
+    for (const service of loadedServices) {
+      if (!service) throw new ConvexError(errorMessages.notFound("servicio"));
+      if (service.barbershopId !== args.barbershopId)
+        throw new ConvexError(errorMessages.unauthorized);
+
+      selectedServices.push(service);
+    }
+
+    const items = buildItems(selectedServices);
+    const totalDuration = itemsTotalDuration(items);
+
     const barberProfile = await ctx.db.get(barber.userProfileDataId);
     if (!barberProfile)
       throw new ConvexError(errorMessages.notFound("perfil de barbero"));
 
-    const endsAt = args.date + service.duration * MINUTE_MS;
+    const endsAt = args.date + totalDuration * MINUTE_MS;
 
     const startOfDay = new Date(args.date);
     startOfDay.setHours(0, 0, 0, 0);
@@ -1367,13 +1441,15 @@ export const agentBook = zInternalMutation({
       .collect();
 
     const candidateServices = await Promise.all(
-      candidates.map((appt) => ctx.db.get(appt.serviceId)),
+      candidates.map((appt) =>
+        appt.items && appt.items.length > 0 ? null : ctx.db.get(appt.serviceId),
+      ),
     );
 
     for (let i = 0; i < candidates.length; i++) {
       const appt = candidates[i];
-      const apptService = candidateServices[i];
-      const apptEnd = appt.date + (apptService?.duration ?? 0) * MINUTE_MS;
+      const width = conflictDurationMinutes(appt, () => candidateServices[i]);
+      const apptEnd = appt.date + width * MINUTE_MS;
       if (appt.date < endsAt && apptEnd > args.date) {
         throw new ConvexError(errorMessages.appointmentOverlaps);
       }
@@ -1382,7 +1458,8 @@ export const agentBook = zInternalMutation({
     const appointmentId = await ctx.db.insert("appointments", {
       userId: args.userId,
       barbershopId: args.barbershopId,
-      serviceId: args.serviceId,
+      serviceId: items[0].serviceId,
+      items,
       barbershopMemberId: args.barbershopMemberId,
       date: args.date,
       customerName: args.customerName,
@@ -1396,7 +1473,7 @@ export const agentBook = zInternalMutation({
     await reserveForAppointment(ctx, {
       _id: appointmentId,
       barbershopId: args.barbershopId,
-      serviceId: args.serviceId,
+      serviceIds: args.serviceIds,
       userId: args.userId,
     });
 
@@ -1433,10 +1510,12 @@ export const agentBook = zInternalMutation({
         appointmentId,
         barbershopId: args.barbershopId,
         source: "agent",
-        serviceId: args.serviceId,
-        serviceName: service.name,
-        servicePrice: service.price,
-        durationMinutes: service.duration,
+        serviceId: items[0].serviceId,
+        serviceIds: args.serviceIds,
+        itemCount: items.length,
+        serviceName: itemsLabel(items),
+        servicePrice: itemsTotal(items),
+        durationMinutes: totalDuration,
         barberId: args.barbershopMemberId,
       },
       groups: { barbershop: args.barbershopId },

--- a/convex/appointments.ts
+++ b/convex/appointments.ts
@@ -163,6 +163,28 @@ export const create = zAuthMutation({
       selectedServices.push(service);
     }
 
+    // The barber must actively offer every selected line — the UI barber
+    // filter is only an aid; assignments can change between selection and
+    // submit.
+    const assignments = await ctx.db
+      .query("barbershopMemberServices")
+      .withIndex("by_barbershopMemberId", (q) =>
+        q.eq("barbershopMemberId", appointment.barbershopMemberId),
+      )
+      .filter((q) => q.neq(q.field("isActive"), false))
+      .collect();
+    const assignedServiceIds = new Set(
+      assignments.map((assignment) => assignment.serviceId),
+    );
+
+    if (
+      !appointment.serviceIds.every((serviceId) =>
+        assignedServiceIds.has(serviceId),
+      )
+    ) {
+      throw new ConvexError(errorMessages.barberDoesNotOfferService);
+    }
+
     const items = buildItems(selectedServices);
     const totalDuration = itemsTotalDuration(items);
 
@@ -1422,7 +1444,8 @@ export const agentBook = zInternalMutation({
       ctx.db.get(args.barbershopId),
     ]);
 
-    if (!barber) throw new ConvexError(errorMessages.notFound("barbero"));
+    if (!barber?.isActive)
+      throw new ConvexError(errorMessages.notFound("barbero"));
     if (!barbershop) throw new ConvexError(errorMessages.notFound("barbería"));
     if (barber.barbershopId !== args.barbershopId)
       throw new ConvexError(errorMessages.unauthorized);
@@ -1437,6 +1460,26 @@ export const agentBook = zInternalMutation({
         throw new ConvexError(errorMessages.unauthorized);
 
       selectedServices.push(service);
+    }
+
+    // The barber must actively offer every selected line — the UI barber
+    // filter is only an aid; assignments can change between selection and
+    // submit.
+    const assignments = await ctx.db
+      .query("barbershopMemberServices")
+      .withIndex("by_barbershopMemberId", (q) =>
+        q.eq("barbershopMemberId", args.barbershopMemberId),
+      )
+      .filter((q) => q.neq(q.field("isActive"), false))
+      .collect();
+    const assignedServiceIds = new Set(
+      assignments.map((assignment) => assignment.serviceId),
+    );
+
+    if (
+      !args.serviceIds.every((serviceId) => assignedServiceIds.has(serviceId))
+    ) {
+      throw new ConvexError(errorMessages.barberDoesNotOfferService);
     }
 
     const items = buildItems(selectedServices);

--- a/convex/appointments.ts
+++ b/convex/appointments.ts
@@ -5,13 +5,7 @@ import { ConvexError } from "convex/values";
 import { convexToZod } from "convex-helpers/server/zod4";
 import { z } from "zod";
 
-import {
-  zAuthMutation,
-  zAuthQuery,
-  zInternalMutation,
-  zInternalQuery,
-  zQuery,
-} from ".";
+import { zAuthMutation, zInternalMutation, zInternalQuery, zQuery } from ".";
 import { internal } from "./_generated/api";
 import type { MutationCtx } from "./_generated/server";
 import { assertCanCreateStaffAppointment } from "./acl";
@@ -436,21 +430,26 @@ export const getRescheduledRequests = zQuery({
   },
 });
 
-export const getByUserId = zAuthQuery({
+export const getByUserId = zQuery({
   args: z.object({
-    userId: z.string(),
+    userId: z.string().optional(),
     paginationOpts: convexToZod(paginationOptsValidator),
   }),
   handler: async (ctx, args) => {
-    const { userId } = ctx;
+    const userId = await getUserId(ctx);
 
-    if (!userId || args.userId !== userId) {
-      throw new ConvexError(errorMessages.unauthorized);
+    // Degrade (don't throw) while the websocket authenticates: this query
+    // re-subscribes before Convex auth lands on callback/full-page loads, and
+    // a throw here unmounts the whole profile route into its error boundary.
+    if (!userId || !args.userId || args.userId !== userId) {
+      return { page: [], isDone: true, continueCursor: "" };
     }
+
+    const targetUserId = args.userId;
 
     const result = await ctx.db
       .query("appointments")
-      .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+      .withIndex("by_userId", (q) => q.eq("userId", targetUserId))
       .order("desc")
       .paginate(args.paginationOpts);
 

--- a/convex/appointments.ts
+++ b/convex/appointments.ts
@@ -497,6 +497,14 @@ export const getById = zQuery({
 export const setStatusSchema = z.object({
   appointment: appointments.tools.id,
   status: z.enum(["completed", "no-show", "cancelled"]),
+  /** Final agreed price per "starting" line — required to complete them. */
+  finalPrices: z
+    .object({
+      serviceId: services.tools.id.shape.id,
+      finalPrice: z.number(),
+    })
+    .array()
+    .optional(),
 });
 
 export const setStatus = zAuthMutation({
@@ -528,18 +536,11 @@ export const setStatus = zAuthMutation({
       throw new ConvexError(errorMessages.unauthorized);
     }
 
-    const member = await getBarbershopMemberByUserId(
-      ctx,
-      appt.barbershopId,
-      userId,
-    );
-
-    if (
-      !member?.isActive ||
-      !memberHasAnyRole(member, ["owner", "barber", "staff"])
-    ) {
-      throw new ConvexError(errorMessages.unauthorized);
-    }
+    await assertShopRole(ctx, appt.barbershopId, userId, [
+      "owner",
+      "barber",
+      "staff",
+    ]);
 
     let updatedAppointment = null;
 
@@ -547,20 +548,52 @@ export const setStatus = zAuthMutation({
       case "completed": {
         await cancelScheduledNotifications(ctx, appt);
 
+        // Every "starting" line needs its agreed final price (≥ the minimum)
+        // to complete. Finals are snapshotted onto the row in the SAME
+        // transaction as the revenue aggregate write below, so they can never
+        // drift apart.
+        const items = await getAppointmentItems(ctx, appt);
+        const finalByService = new Map(
+          (args.finalPrices ?? []).map((entry) => [
+            entry.serviceId,
+            entry.finalPrice,
+          ]),
+        );
+
+        const itemsWithFinals = items.map((item) => {
+          if (item.priceType !== "starting") {
+            return item;
+          }
+
+          const finalPrice =
+            item.finalPrice ?? finalByService.get(item.serviceId);
+
+          if (finalPrice === undefined) {
+            throw new ConvexError(errorMessages.finalPriceRequired(item.name));
+          }
+
+          if (finalPrice < item.price) {
+            throw new ConvexError(
+              errorMessages.finalPriceBelowMinimum(item.name),
+            );
+          }
+
+          return { ...item, finalPrice };
+        });
+
         updatedAppointment = await ctx.db.patch(appointmentId, {
           status: "completed",
+          items: itemsWithFinals,
           upcomingNotificationId: undefined,
           pastReminderNotificationId: undefined,
         });
 
         // Release the recipe holds and consume the stock the services used.
-        const consumedItems = await getAppointmentItems(ctx, appt);
-
         await consumeForAppointment(ctx, {
           _id: appointmentId,
           barbershopId: appt.barbershopId,
           userId: appt.userId,
-          serviceIds: consumedItems.map((item) => item.serviceId),
+          serviceIds: itemsWithFinals.map((item) => item.serviceId),
         });
 
         await ctx.runMutation(

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -49,19 +49,24 @@ async function findAvailableBarberForSlot(
   const dayIndex = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
   const dayName = DAY_MAP[dayIndex];
   const apptMinutes = minutesOfDay(appointment.date);
+  const lineServiceIds = appointment.items?.length
+    ? appointment.items.map((line) => line.serviceId)
+    : [appointment.serviceId];
 
   for (const candidate of candidates) {
-    const hasService = await ctx.db
+    const assignments = await ctx.db
       .query("barbershopMemberServices")
-      .withIndex("by_barbershopMemberId_and_serviceId", (q) =>
-        q
-          .eq("barbershopMemberId", candidate._id)
-          .eq("serviceId", appointment.serviceId),
+      .withIndex("by_barbershopMemberId", (q) =>
+        q.eq("barbershopMemberId", candidate._id),
       )
       .filter((q) => q.neq(q.field("isActive"), false))
-      .first();
+      .collect();
+    const assignedServiceIds = new Set(
+      assignments.map((assignment) => assignment.serviceId),
+    );
 
-    if (!hasService) continue;
+    if (!lineServiceIds.every((serviceId) => assignedServiceIds.has(serviceId)))
+      continue;
 
     const schedule = candidate.availability ?? barbershop.availability;
     const daySchedule = schedule.find((s) => s.weekDay.day === dayName);

--- a/convex/barbershopMemberServices.ts
+++ b/convex/barbershopMemberServices.ts
@@ -17,7 +17,7 @@ export const getBarbershopBarbers = zQuery({
     const members = await ctx.db
       .query("barbershopMembers")
       .withIndex("by_barbershopId", (q) => q.eq("barbershopId", args.id))
-      .filter((q) => q.eq(q.field("isActive"), true))
+      .filter((q) => q.neq(q.field("isActive"), false))
       .collect();
 
     const barbers = members.filter((member) => member.roles.includes("barber"));
@@ -78,7 +78,7 @@ async function barbersOfferingAllServices(
       const assignments = await ctx.db
         .query("barbershopMemberServices")
         .withIndex("by_serviceId", (q) => q.eq("serviceId", serviceId))
-        .filter((q) => q.eq(q.field("isActive"), true))
+        .filter((q) => q.neq(q.field("isActive"), false))
         .collect();
 
       return new Set(assignments.map((a) => a.barbershopMemberId));

--- a/convex/barbershopMemberServices.ts
+++ b/convex/barbershopMemberServices.ts
@@ -4,9 +4,11 @@ import { ConvexError } from "convex/values";
 import { z } from "zod";
 
 import { zAuthMutation, zInternalMutation, zQuery } from ".";
+import type { QueryCtx } from "./_generated/server";
 import { assertCanManageTeam } from "./authz";
 import { errorMessages } from "./errors";
 import { rateLimitOrThrow } from "./ratelimit";
+import type { Service } from "./schema";
 import { barbershopMembers, barbershops, services } from "./schema";
 
 export const getBarbershopBarbers = zQuery({
@@ -62,6 +64,57 @@ export const getServicesForBarber = zQuery({
   },
 });
 
+/** Active barbers explicitly assigned to EVERY service in the set. */
+async function barbersOfferingAllServices(
+  ctx: QueryCtx,
+  serviceIds: Service["_id"][],
+) {
+  if (serviceIds.length === 0) {
+    return [];
+  }
+
+  const assignmentSets = await Promise.all(
+    serviceIds.map(async (serviceId) => {
+      const assignments = await ctx.db
+        .query("barbershopMemberServices")
+        .withIndex("by_serviceId", (q) => q.eq("serviceId", serviceId))
+        .filter((q) => q.eq(q.field("isActive"), true))
+        .collect();
+
+      return new Set(assignments.map((a) => a.barbershopMemberId));
+    }),
+  );
+
+  const [firstSet, ...restSets] = assignmentSets;
+  const memberIds = [...firstSet].filter((memberId) =>
+    restSets.every((set) => set.has(memberId)),
+  );
+
+  if (memberIds.length === 0) {
+    return [];
+  }
+
+  const barbers = await Promise.all(
+    memberIds.map(async (memberId) => {
+      const member = await ctx.db.get(memberId);
+
+      if (!member?.isActive) return null;
+
+      const profile = await ctx.db.get(member.userProfileDataId);
+
+      return {
+        ...member,
+        name: profile?.name ?? "",
+        email: profile?.email ?? "",
+        phoneNumber: profile?.phoneNumber ?? "",
+        avatarUrl: profile?.image ?? "",
+      };
+    }),
+  );
+
+  return barbers.filter((b) => b?.roles?.includes("barber"));
+}
+
 /**
  * Get all barbers who offer a specific service.
  * Only returns barbers who are explicitly assigned to this service.
@@ -70,35 +123,17 @@ export const getServicesForBarber = zQuery({
 export const getBarbersForService = zQuery({
   args: services.tools.id,
   handler: async (ctx, args) => {
-    const assignments = await ctx.db
-      .query("barbershopMemberServices")
-      .withIndex("by_serviceId", (q) => q.eq("serviceId", args.id))
-      .filter((q) => q.eq(q.field("isActive"), true))
-      .collect();
+    return await barbersOfferingAllServices(ctx, [args.id]);
+  },
+});
 
-    if (assignments.length === 0) {
-      return [];
-    }
-
-    const barbers = await Promise.all(
-      assignments.map(async (a) => {
-        const member = await ctx.db.get(a.barbershopMemberId);
-
-        if (!member?.isActive) return null;
-
-        const profile = await ctx.db.get(member.userProfileDataId);
-
-        return {
-          ...member,
-          name: profile?.name ?? "",
-          email: profile?.email ?? "",
-          phoneNumber: profile?.phoneNumber ?? "",
-          avatarUrl: profile?.image ?? "",
-        };
-      }),
-    );
-
-    return barbers.filter((b) => b?.roles?.includes("barber"));
+/** Barbers assigned to ALL of the selected services (multi-service booking). */
+export const getBarbersForServices = zQuery({
+  args: z.object({
+    serviceIds: services.tools.id.shape.id.array(),
+  }),
+  handler: async (ctx, args) => {
+    return await barbersOfferingAllServices(ctx, args.serviceIds);
   },
 });
 

--- a/convex/barbershopMemberServices.ts
+++ b/convex/barbershopMemberServices.ts
@@ -112,7 +112,9 @@ async function barbersOfferingAllServices(
     }),
   );
 
-  return barbers.filter((b) => b?.roles?.includes("barber"));
+  return barbers.filter(
+    (b): b is NonNullable<typeof b> => !!b && b.roles.includes("barber"),
+  );
 }
 
 /**

--- a/convex/barbershopMetadata.ts
+++ b/convex/barbershopMetadata.ts
@@ -3,6 +3,11 @@ import { z } from "zod";
 
 import { zAuthMutation, zInternalMutation, zQuery } from ".";
 import { completedAppointmentsAggregate } from "./aggregates";
+import {
+  getAppointmentItems,
+  itemsLabel,
+  itemsTotal,
+} from "./appointmentItems";
 import { assertCanManageTeam, assertOwner } from "./authz";
 import { errorMessages } from "./errors";
 import { barbershopGeospatial } from "./geospatial";
@@ -141,24 +146,23 @@ export const incrementCompletedAppointments = zInternalMutation({
       throw new ConvexError(errorMessages.notFound("cita"));
     }
 
-    // Snapshot the service price at completion time so the revenue sum is
-    // immune to later price edits. A missing service contributes 0.
-    const service = await ctx.db.get(appointment.serviceId);
-    const price = service?.price ?? 0;
+    // Total = Σ(finalPrice ?? price) over the row's line snapshots (setStatus
+    // patches them, finals included, before invoking this mutation in the same
+    // transaction), so the revenue sum is immune to later service edits. The
+    // legacy mirrors keep the joined label / total for old readers.
+    const items = await getAppointmentItems(ctx, appointment);
+    const total = itemsTotal(items);
 
-    // Mirror the same snapshot onto the row so the 90-day operations breakdown
-    // (which joins per-service, not just the aggregate sum) survives later
-    // service edits/deletion.
     await ctx.db.patch(args.appointmentId, {
-      completedServicePrice: price,
-      completedServiceName: service?.name,
+      completedServicePrice: total,
+      completedServiceName: itemsLabel(items),
     });
 
     await completedAppointmentsAggregate.insert(ctx, {
       namespace: args.barbershopId,
       key: appointment.date,
       id: args.appointmentId,
-      sumValue: price,
+      sumValue: total,
     });
   },
 });

--- a/convex/cascade.ts
+++ b/convex/cascade.ts
@@ -28,8 +28,9 @@ import {
  * Intentional non-rules:
  * - appointments → reviews: reviews outlive their appointment (author/service
  *   name snapshots) — never cascade them from an appointment.
- * - services → appointments: appointments keep a serviceName snapshot and
- *   survive service deletion (they are soft-cancelled by `deleteService`).
+ * - services → appointments: appointments keep line-item snapshots and
+ *   survive service deletion — `deleteService` soft-cancels sole-line citas
+ *   and drops the line from multi-service ones.
  * - inventoryItems → levels/movements: items are soft-deleted (`archiveItem`);
  *   their ledger rows are only removed by the shop-level rules.
  */

--- a/convex/dashboardAnalytics.ts
+++ b/convex/dashboardAnalytics.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 
 import { zAuthQuery } from ".";
 import { completedAppointmentsAggregate } from "./aggregates";
+import { itemsTotal, normalizeItems } from "./appointmentItems";
 import { assertShopRole } from "./authz";
 import type { BarbershopMember, Service } from "./schema";
 import { barbershops } from "./schema";
@@ -156,35 +157,36 @@ export const getOperationsBreakdown = zAuthQuery({
       }
 
       const liveService = serviceById.get(appointment.serviceId);
-      const price =
-        appointment.completedServicePrice ?? liveService?.price ?? 0;
-      const serviceName =
-        appointment.completedServiceName ?? liveService?.name ?? "Servicio";
+      const items = normalizeItems(appointment, liveService);
+      const rowTotal = itemsTotal(items);
 
       totals.completed += 1;
-      totals.revenue += price;
+      totals.revenue += rowTotal;
 
       const barber = perBarber.get(appointment.barbershopMemberId) ?? {
         completed: 0,
         revenue: 0,
       };
       barber.completed += 1;
-      barber.revenue += price;
+      barber.revenue += rowTotal;
       perBarber.set(appointment.barbershopMemberId, barber);
 
-      const service = perService.get(appointment.serviceId) ?? {
-        completed: 0,
-        revenue: 0,
-        name: serviceName,
-      };
-      service.completed += 1;
-      service.revenue += price;
-      // A concrete (snapshot or live) name beats the "Servicio" fallback, so a
-      // deleted service still labels correctly if any of its rows carries one.
-      if (service.name === "Servicio" && serviceName !== "Servicio") {
-        service.name = serviceName;
+      for (const line of items) {
+        const amount = line.finalPrice ?? line.price;
+        const service = perService.get(line.serviceId) ?? {
+          completed: 0,
+          revenue: 0,
+          name: line.name,
+        };
+        service.completed += 1;
+        service.revenue += amount;
+        // A concrete (snapshot or live) name beats the "Servicio" fallback, so
+        // a deleted service still labels correctly if any row carries one.
+        if (service.name === "Servicio" && line.name !== "Servicio") {
+          service.name = line.name;
+        }
+        perService.set(line.serviceId, service);
       }
-      perService.set(appointment.serviceId, service);
 
       const [year, month, day] = toColombiaDateKey(appointment.date)
         .split("-")

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -13,6 +13,7 @@ import {
   AppointmentReassignedEmail,
   AppointmentReminderEmail,
   AppointmentRescheduleRequestEmail,
+  AppointmentUpdatedEmail,
   LowStockEmail,
   PastAppointmentReminderEmail,
   RescheduleRequestAcceptEmail,
@@ -105,7 +106,7 @@ export const sendAppointmentUpdated = zInternalAction({
     await sendEmail(ctx, {
       to: args.to,
       subject: subjects.service_line_removed,
-      react: AppointmentCancelledEmail({
+      react: AppointmentUpdatedEmail({
         notes: args.notes,
         subject: subjects.service_line_removed,
         body: args.body,

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -95,6 +95,25 @@ export const sendAppointmentCancelled = zInternalAction({
   },
 });
 
+export const sendAppointmentUpdated = zInternalAction({
+  args: z.object({
+    notes: z.string(),
+    to: z.string(),
+    body: z.string(),
+  }),
+  handler: async (ctx, args) => {
+    await sendEmail(ctx, {
+      to: args.to,
+      subject: subjects.service_line_removed,
+      react: AppointmentCancelledEmail({
+        notes: args.notes,
+        subject: subjects.service_line_removed,
+        body: args.body,
+      }),
+    });
+  },
+});
+
 export const sendAppointmentRescheduleRequestEmail = zInternalAction({
   args: z.object({
     to: z.string(),

--- a/convex/errors.ts
+++ b/convex/errors.ts
@@ -8,6 +8,10 @@ export const errorMessages = {
   duplicateAppointmentService: "No repitas servicios en la misma cita.",
   cannotRescheduleCompleted:
     "No puedes reprogramar una cita que ya fue completada.",
+  finalPriceRequired: (serviceName: string) =>
+    `Ingresa el precio final acordado para "${serviceName}" antes de completar la cita.`,
+  finalPriceBelowMinimum: (serviceName: string) =>
+    `El precio final de "${serviceName}" no puede ser menor al precio mínimo publicado.`,
   notFound: (resource: string) => `El recurso "${resource}" no fue encontrado`,
   barbershopClosedOnSelectedDay:
     "La barbería no está abierta en el día seleccionado",

--- a/convex/errors.ts
+++ b/convex/errors.ts
@@ -5,6 +5,7 @@ export const errorMessages = {
     "La barbería no está abierta en el horario seleccionado.",
   appointmentUnavailableHours:
     "La barbería no atiende durante el horario seleccionado.",
+  duplicateAppointmentService: "No repitas servicios en la misma cita.",
   cannotRescheduleCompleted:
     "No puedes reprogramar una cita que ya fue completada.",
   notFound: (resource: string) => `El recurso "${resource}" no fue encontrado`,

--- a/convex/errors.ts
+++ b/convex/errors.ts
@@ -6,6 +6,8 @@ export const errorMessages = {
   appointmentUnavailableHours:
     "La barbería no atiende durante el horario seleccionado.",
   duplicateAppointmentService: "No repitas servicios en la misma cita.",
+  barberDoesNotOfferService:
+    "El barbero seleccionado no ofrece todos los servicios elegidos. Elige otro barbero o ajusta los servicios.",
   cannotRescheduleCompleted:
     "No puedes reprogramar una cita que ya fue completada.",
   finalPriceRequired: (serviceName: string) =>

--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -1271,10 +1271,15 @@ export const getServiceSupplyCounts = zAuthQuery({
 // whose plan lacks inventory.
 // ---------------------------------------------------------------------------
 
-type AppointmentStockContext = Pick<
+type AppointmentLedgerContext = Pick<
   Appointment,
-  "_id" | "barbershopId" | "serviceId" | "userId"
+  "_id" | "barbershopId" | "userId"
 >;
+
+type AppointmentStockContext = AppointmentLedgerContext & {
+  /** Every booked line's service — recipes reserve/consume per line. */
+  serviceIds: Service["_id"][];
+};
 
 async function movementsForAppointment(
   ctx: MutationCtx,
@@ -1314,7 +1319,7 @@ function outstandingFrom(movements: InventoryMovement[]) {
   return [...outstanding.values()].filter((entry) => entry.quantity > 0);
 }
 
-/** Reserve the service's recipe on booking (both `create` and `agentBook`). */
+/** Reserve every line's recipe on booking (both `create` and `agentBook`). */
 export async function reserveForAppointment(
   ctx: MutationCtx,
   appointment: AppointmentStockContext,
@@ -1335,34 +1340,36 @@ export async function reserveForAppointment(
     return;
   }
 
-  const recipe = await ctx.db
-    .query("serviceInventoryUsage")
-    .withIndex("by_serviceId", (q) => q.eq("serviceId", appointment.serviceId))
-    .collect();
+  for (const serviceId of appointment.serviceIds) {
+    const recipe = await ctx.db
+      .query("serviceInventoryUsage")
+      .withIndex("by_serviceId", (q) => q.eq("serviceId", serviceId))
+      .collect();
 
-  for (const line of recipe) {
-    const item = await ctx.db.get(line.itemId);
+    for (const line of recipe) {
+      const item = await ctx.db.get(line.itemId);
 
-    if (!item || item.deletedAt !== undefined) {
-      continue;
+      if (!item || item.deletedAt !== undefined) {
+        continue;
+      }
+
+      // Legacy recipe lines may predate the durable guard — never hold assets.
+      if (item.stockBehavior === "durable") {
+        continue;
+      }
+
+      // Partial reservations are fine: release/consume work from outstanding.
+      await recordMovement(ctx, {
+        barbershopId: appointment.barbershopId,
+        itemId: line.itemId,
+        type: "reservation",
+        quantity: line.quantity,
+        relatedAppointmentId: appointment._id,
+        reason: "Reserva por cita",
+        actorUserId: appointment.userId,
+        clampToAvailable: true,
+      });
     }
-
-    // Legacy recipe lines may predate the durable guard — never hold assets.
-    if (item.stockBehavior === "durable") {
-      continue;
-    }
-
-    // Partial reservations are fine: release/consume work from outstanding.
-    await recordMovement(ctx, {
-      barbershopId: appointment.barbershopId,
-      itemId: line.itemId,
-      type: "reservation",
-      quantity: line.quantity,
-      relatedAppointmentId: appointment._id,
-      reason: "Reserva por cita",
-      actorUserId: appointment.userId,
-      clampToAvailable: true,
-    });
   }
 }
 
@@ -1374,7 +1381,7 @@ export async function reserveForAppointment(
  */
 export async function releaseForAppointment(
   ctx: MutationCtx,
-  appointment: AppointmentStockContext,
+  appointment: AppointmentLedgerContext,
   reason = "Liberación por cita cancelada",
 ): Promise<void> {
   const movements = await movementsForAppointment(ctx, appointment._id);
@@ -1395,8 +1402,8 @@ export async function releaseForAppointment(
 }
 
 /**
- * Completion: release the holds, then consume the CURRENT recipe (clamped to
- * onHand for strict items, shortfall noted in the reason — the
+ * Completion: release the holds, then consume every line's CURRENT recipe
+ * (clamped to onHand for strict items, shortfall noted in the reason — the
  * completed-but-stock-changed race never blocks the barber).
  */
 export async function consumeForAppointment(
@@ -1428,33 +1435,35 @@ export async function consumeForAppointment(
     return;
   }
 
-  const recipe = await ctx.db
-    .query("serviceInventoryUsage")
-    .withIndex("by_serviceId", (q) => q.eq("serviceId", appointment.serviceId))
-    .collect();
+  for (const serviceId of appointment.serviceIds) {
+    const recipe = await ctx.db
+      .query("serviceInventoryUsage")
+      .withIndex("by_serviceId", (q) => q.eq("serviceId", serviceId))
+      .collect();
 
-  for (const line of recipe) {
-    const item = await ctx.db.get(line.itemId);
+    for (const line of recipe) {
+      const item = await ctx.db.get(line.itemId);
 
-    if (!item || item.deletedAt !== undefined) {
-      continue;
+      if (!item || item.deletedAt !== undefined) {
+        continue;
+      }
+
+      // Legacy recipe lines may predate the durable guard — never consume assets.
+      if (item.stockBehavior === "durable") {
+        continue;
+      }
+
+      await recordMovement(ctx, {
+        barbershopId: appointment.barbershopId,
+        itemId: line.itemId,
+        type: "consumption",
+        quantity: line.quantity,
+        relatedAppointmentId: appointment._id,
+        reason: "Consumo por servicio",
+        actorUserId: appointment.userId,
+        clampToAvailable: true,
+      });
     }
-
-    // Legacy recipe lines may predate the durable guard — never consume assets.
-    if (item.stockBehavior === "durable") {
-      continue;
-    }
-
-    await recordMovement(ctx, {
-      barbershopId: appointment.barbershopId,
-      itemId: line.itemId,
-      type: "consumption",
-      quantity: line.quantity,
-      relatedAppointmentId: appointment._id,
-      reason: "Consumo por servicio",
-      actorUserId: appointment.userId,
-      clampToAvailable: true,
-    });
   }
 }
 

--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -1402,6 +1402,60 @@ export async function releaseForAppointment(
 }
 
 /**
+ * Free the holds attributable to ONE dropped line (`deleteService` drop-line
+ * flow). Reservations aren't tagged per service in the ledger, so this
+ * releases min(outstanding, recipe quantity) per item of the dropped
+ * service's CURRENT recipe. IRON RULE: never throws.
+ */
+export async function releaseServiceLineForAppointment(
+  ctx: MutationCtx,
+  appointment: AppointmentLedgerContext,
+  droppedServiceId: Service["_id"],
+): Promise<void> {
+  const movements = await movementsForAppointment(ctx, appointment._id);
+  const outstanding = outstandingFrom(movements);
+
+  if (outstanding.length === 0) {
+    return;
+  }
+
+  const recipe = await ctx.db
+    .query("serviceInventoryUsage")
+    .withIndex("by_serviceId", (q) => q.eq("serviceId", droppedServiceId))
+    .collect();
+
+  for (const line of recipe) {
+    const entry = outstanding.find(
+      (candidate) => candidate.itemId === line.itemId,
+    );
+
+    if (!entry) {
+      continue;
+    }
+
+    const quantity = Math.min(entry.quantity, line.quantity);
+
+    if (quantity <= 0) {
+      continue;
+    }
+
+    await recordMovement(ctx, {
+      barbershopId: appointment.barbershopId,
+      itemId: line.itemId,
+      type: "release",
+      quantity,
+      locationId: entry.locationId,
+      relatedAppointmentId: appointment._id,
+      reason: "Liberación por servicio removido de la cita",
+      actorUserId: appointment.userId,
+      clampToAvailable: true,
+    });
+
+    entry.quantity -= quantity;
+  }
+}
+
+/**
  * Completion: release the holds, then consume every line's CURRENT recipe
  * (clamped to onHand for strict items, shortfall noted in the reason — the
  * completed-but-stock-changed race never blocks the barber).

--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -1404,13 +1404,17 @@ export async function releaseForAppointment(
 /**
  * Free the holds attributable to ONE dropped line (`deleteService` drop-line
  * flow). Reservations aren't tagged per service in the ledger, so this
- * releases min(outstanding, recipe quantity) per item of the dropped
- * service's CURRENT recipe. IRON RULE: never throws.
+ * releases min(outstanding surplus, recipe quantity) per item of the dropped
+ * service's CURRENT recipe, where surplus is what exceeds the surviving
+ * lines' remaining needs — a clamped reservation may belong to a surviving
+ * line, and under-releasing self-heals at the terminal states. IRON RULE:
+ * never throws.
  */
 export async function releaseServiceLineForAppointment(
   ctx: MutationCtx,
   appointment: AppointmentLedgerContext,
   droppedServiceId: Service["_id"],
+  survivingServiceIds: Service["_id"][],
 ): Promise<void> {
   const movements = await movementsForAppointment(ctx, appointment._id);
   const outstanding = outstandingFrom(movements);
@@ -1419,10 +1423,23 @@ export async function releaseServiceLineForAppointment(
     return;
   }
 
-  const recipe = await ctx.db
-    .query("serviceInventoryUsage")
-    .withIndex("by_serviceId", (q) => q.eq("serviceId", droppedServiceId))
-    .collect();
+  const [recipe, ...survivingRecipes] = await Promise.all(
+    [droppedServiceId, ...survivingServiceIds].map((serviceId) =>
+      ctx.db
+        .query("serviceInventoryUsage")
+        .withIndex("by_serviceId", (q) => q.eq("serviceId", serviceId))
+        .collect(),
+    ),
+  );
+
+  const neededBySurvivors = new Map<string, number>();
+
+  for (const survivorLine of survivingRecipes.flat()) {
+    neededBySurvivors.set(
+      survivorLine.itemId,
+      (neededBySurvivors.get(survivorLine.itemId) ?? 0) + survivorLine.quantity,
+    );
+  }
 
   for (const line of recipe) {
     const entry = outstanding.find(
@@ -1433,7 +1450,11 @@ export async function releaseServiceLineForAppointment(
       continue;
     }
 
-    const quantity = Math.min(entry.quantity, line.quantity);
+    const surplus = Math.max(
+      0,
+      entry.quantity - (neededBySurvivors.get(line.itemId) ?? 0),
+    );
+    const quantity = Math.min(surplus, line.quantity);
 
     if (quantity <= 0) {
       continue;

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -6,6 +6,7 @@ import {
   reviewStarsAggregate,
   reviewStarsNamespace,
 } from "./aggregates";
+import { normalizeItems } from "./appointmentItems";
 import { authz, barbershopScope } from "./authz";
 
 export const migrations = new Migrations<DataModel>(components.migrations);
@@ -98,6 +99,29 @@ export const backfillCompletedServiceSnapshot = migrations.define({
     await ctx.db.patch(appointment._id, {
       completedServicePrice: service.price,
       completedServiceName: service.name,
+    });
+  },
+});
+
+/**
+ * Backfill canonical line items onto pre-multi-service appointments. Rows that
+ * already carry `items` are skipped; the rest get ONE fixed line synthesized
+ * exactly like `appointmentItems.normalizeItems` — completed rows prefer the
+ * completion-time snapshot, then the live service, then "Servicio" / 0 / 30.
+ * Never touches the revenue aggregate. Idempotent. Run once with
+ * `npx convex run migrations:run '{fn: "migrations:backfillAppointmentItems"}'`.
+ */
+export const backfillAppointmentItems = migrations.define({
+  table: "appointments",
+  migrateOne: async (ctx, appointment) => {
+    if (appointment.items && appointment.items.length > 0) {
+      return;
+    }
+
+    const liveService = await ctx.db.get(appointment.serviceId);
+
+    await ctx.db.patch(appointment._id, {
+      items: normalizeItems(appointment, liveService),
     });
   },
 });

--- a/convex/notificationCopy.ts
+++ b/convex/notificationCopy.ts
@@ -102,6 +102,11 @@ export type NotificationInput =
       serviceName: string;
     }
   | {
+      kind: "service_line_removed";
+      barbershopName: string;
+      serviceName: string;
+    }
+  | {
       kind: "review_invite";
       barbershopName: string;
       barbershopUuid: string;
@@ -240,6 +245,14 @@ export function buildNotificationCopy(
         kind: "service_deleted_cancellation",
         title: subjects.appointment_cancelled,
         description: `Tu cita en ${input.barbershopName} ha sido cancelada porque el servicio "${input.serviceName}" ya no está disponible.`,
+        href: deepLinks.customerAppointments(),
+      };
+    }
+    case "service_line_removed": {
+      return {
+        kind: "service_line_removed",
+        title: subjects.service_line_removed,
+        description: `Tu cita en ${input.barbershopName} se actualizó: el servicio "${input.serviceName}" ya no está disponible y se quitó de tu reserva. El resto de tu cita sigue confirmada.`,
         href: deepLinks.customerAppointments(),
       };
     }

--- a/convex/notificationSubjects.ts
+++ b/convex/notificationSubjects.ts
@@ -16,6 +16,7 @@ export const subjects = {
   barber_appointment_created: "Nueva cita en tu barbería",
   team_invited: "Invitación a unirte a la barbería",
   past_appointment_reminder: "Recordatorio de cita pasada",
+  service_line_removed: "Tu cita se actualizó",
   review_invite: "Califica tu visita",
   review_needs_attention: "Tu reseña necesita atención",
   low_stock: "Inventario bajo",

--- a/convex/notifications.ts
+++ b/convex/notifications.ts
@@ -843,3 +843,79 @@ export const createServiceDeletedCancellation = zInternalMutation({
     }
   },
 });
+
+/**
+ * Notification when a multi-service appointment loses one line because that
+ * service was deleted. The rest of the cita stays confirmed — copy and email
+ * subject say "updated", not "cancelled".
+ */
+export const createServiceLineRemoved = zInternalMutation({
+  args: z.object({
+    appointmentId: zid("appointments"),
+    customerUserId: z.string(),
+    serviceName: z.string(),
+    barbershopName: z.string(),
+    contactPhone: z.string(),
+    contactEmail: z.string().optional(),
+  }),
+  handler: async (ctx, args) => {
+    const [customerProfile, appointment] = await Promise.all([
+      getProfileByUserId(ctx, args.customerUserId),
+      ctx.db.get(args.appointmentId),
+    ]);
+
+    const copy = buildNotificationCopy({
+      kind: "service_line_removed",
+      barbershopName: args.barbershopName,
+      serviceName: args.serviceName,
+    });
+    const body = copy.description;
+    const smsBody = buildSmsBody(copy);
+
+    const toEmail = resolveCustomerEmail(
+      args.contactEmail,
+      customerProfile?.email,
+    );
+
+    const emailEnabled = customerProfile
+      ? isNotificationEnabled("email", customerProfile.notificationsPreferences)
+      : true; // Default to enabled for guests
+
+    if (emailEnabled && toEmail) {
+      await scheduleEmailWithQuota(ctx, appointment?.barbershopId, () =>
+        ctx.scheduler.runAfter(0, internal.emails.sendAppointmentUpdated, {
+          notes: `Servicio "${args.serviceName}" removido de la cita`,
+          to: toEmail,
+          body,
+        }),
+      );
+    }
+
+    const phoneNumber = customerProfile?.phoneNumber ?? args.contactPhone;
+
+    const smsEnabled = customerProfile
+      ? isNotificationEnabled("sms", customerProfile.notificationsPreferences)
+      : true; // Default to enabled for guests
+
+    if (smsEnabled) {
+      await scheduleSmsWithQuota(ctx, {
+        body: smsBody,
+        to: phoneNumber,
+        barbershopId: appointment?.barbershopId,
+      });
+    }
+
+    if (customerProfile?.userId) {
+      await recordInApp(ctx, {
+        userId: customerProfile.userId,
+        copy,
+        payload: {
+          appointmentId: args.appointmentId,
+          barbershopId: appointment?.barbershopId,
+          barbershopName: args.barbershopName,
+          serviceName: args.serviceName,
+        },
+      });
+    }
+  },
+});

--- a/convex/reviews.ts
+++ b/convex/reviews.ts
@@ -21,6 +21,7 @@ import {
   reviewStarsNamespace,
 } from "./aggregates";
 import { track } from "./analytics";
+import { getAppointmentItems, itemsLabel } from "./appointmentItems";
 import { assertShopRole } from "./authz";
 import { errorMessages } from "./errors";
 import { getUserId } from "./identity";
@@ -165,8 +166,8 @@ export const create = zAuthMutation({
       throw new ConvexError(errorMessages.reviewAlreadyExists);
     }
 
-    const [service, profile] = await Promise.all([
-      ctx.db.get(appointment.serviceId),
+    const [items, profile] = await Promise.all([
+      getAppointmentItems(ctx, appointment),
       getProfileByUserId(ctx, userId),
     ]);
 
@@ -179,7 +180,7 @@ export const create = zAuthMutation({
       barbershopId: appointment.barbershopId,
       appointmentId: appointment._id,
       serviceId: appointment.serviceId,
-      serviceName: service?.name ?? "Servicio",
+      serviceName: itemsLabel(items),
       authorName: profile?.name ?? appointment.customerName,
     });
 
@@ -490,9 +491,9 @@ export const getReviewableAppointments = zAuthQuery({
         continue;
       }
 
-      const [barbershop, service] = await Promise.all([
+      const [barbershop, items] = await Promise.all([
         ctx.db.get(appointment.barbershopId),
-        ctx.db.get(appointment.serviceId),
+        getAppointmentItems(ctx, appointment),
       ]);
 
       if (!barbershop) {
@@ -505,7 +506,7 @@ export const getReviewableAppointments = zAuthQuery({
         barbershopUuid: barbershop.uuid,
         barbershopName: barbershop.name ?? "Barbería",
         logoKey: barbershop.logoKey,
-        serviceName: service?.name ?? "Servicio",
+        serviceName: itemsLabel(items),
         date: appointment.date,
       });
     }
@@ -564,11 +565,11 @@ export const getReviewableForBarbershop = zQuery({
         continue;
       }
 
-      const service = await ctx.db.get(appointment.serviceId);
+      const items = await getAppointmentItems(ctx, appointment);
 
       return {
         appointmentId: appointment._id,
-        serviceName: service?.name ?? "Servicio",
+        serviceName: itemsLabel(items),
         date: appointment.date,
       };
     }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,4 +1,5 @@
 import { defineSchema } from "convex/server";
+import { zid } from "convex-helpers/server/zod4";
 import type { output } from "zod";
 import { z } from "zod";
 
@@ -134,6 +135,11 @@ export const services = zodTable("services", (id) => ({
     .number({ error: "La duración es requerida" })
     .min(5, { error: "La duración debe ser mayor a 5 minutos" })
     .max(480, { error: "La duración debe ser menor a 8 horas" }),
+  /**
+   * "starting" prices are a binding minimum shown as "Desde $X"; the final
+   * price is agreed in person and recorded at completion. Absent = fixed.
+   */
+  priceType: z.enum(["fixed", "starting"]).optional(),
   barbershopId: id("barbershops"),
 }));
 
@@ -164,6 +170,24 @@ export const reviews = zodTable("reviews", (id) => ({
   /** Short Spanish explanation shown to the author when a review is flagged. */
   moderationReason: z.string().optional(),
 }));
+
+/**
+ * One booked service line, snapshotted at booking time so name/price/duration
+ * survive later service edits/deletion. `finalPrice` is set at completion for
+ * "starting"-priced lines (agreed in person, must be ≥ `price`).
+ */
+const appointmentItem = (id: typeof zid) =>
+  z.object({
+    serviceId: id("services"),
+    name: z.string(),
+    price: z.number(),
+    priceType: z.enum(["fixed", "starting"]),
+    duration: z.number(),
+    finalPrice: z.number().optional(),
+  });
+
+/** Standalone (real zid) variant for function arg validators. */
+export const appointmentItemSchema = appointmentItem(zid);
 
 export const appointments = zodTable("appointments", (id) => ({
   userId: z.string(),
@@ -235,6 +259,14 @@ export const appointments = zodTable("appointments", (id) => ({
    */
   completedServicePrice: z.number().optional(),
   completedServiceName: z.string().optional(),
+  /**
+   * Canonical booked lines (booking-time snapshots). Optional in the table so
+   * pre-migration rows validate, but written by every new booking; legacy rows
+   * synthesize a single line via `appointmentItems.ts` until the backfill
+   * runs. `serviceId` above stays as the denormalized primary line
+   * (≡ items[0].serviceId).
+   */
+  items: appointmentItem(id).array().optional(),
 }));
 
 export const barbershopMemberServices = zodTable(
@@ -305,6 +337,7 @@ export const notificationKinds = [
   "team_invited",
   "barber_removed_cancellation",
   "service_deleted_cancellation",
+  "service_line_removed",
   "review_invite",
   "review_needs_attention",
   "low_stock",
@@ -934,6 +967,7 @@ export type BarbershopMetadataWithCount = BarbershopMetadata & {
 export type Service = output<typeof services.schema>;
 export type Review = output<typeof reviews.schema>;
 export type Appointment = output<typeof appointments.schema>;
+export type AppointmentItem = output<typeof appointmentItemSchema>;
 export type BarbershopMemberServices = output<
   typeof barbershopMemberServices.schema
 >;

--- a/convex/services.ts
+++ b/convex/services.ts
@@ -9,8 +9,12 @@ import { track } from "./analytics";
 import { assertCanManageServices, assertCanManageTeam } from "./authz";
 import { cascadingDelete } from "./cascade";
 import { errorMessages } from "./errors";
-import { releaseForAppointment } from "./inventory";
+import {
+  releaseForAppointment,
+  releaseServiceLineForAppointment,
+} from "./inventory";
 import { rateLimitOrThrow } from "./ratelimit";
+import type { Appointment } from "./schema";
 import { appointments, barbershops, services } from "./schema";
 
 export const create = zAuthMutation({
@@ -131,11 +135,24 @@ export const update = zAuthMutation({
 });
 
 /**
- * Delete a service with 2-step confirmation if future appointments exist.
+ * Delete a service with 2-step confirmation if future appointments reference it.
  *
- * - If `force` is false/undefined and impacted appointments exist:
- *   throws ConvexError with message "WILL_CANCEL:N" where N is count of impacted appointments.
- * - If `force` is true: cancels/soft-deletes all impacted appointments, notifies customers, then deletes service.
+ * - If `force` is false/undefined and impacted appointments exist: throws
+ *   ConvexError "WILL_CANCEL:N:WILL_UPDATE:M" — N citas whose ONLY service is
+ *   this one (they will be cancelled), M multi-service citas (they lose this
+ *   line but survive).
+ * - If `force` is true: cancels the sole-line citas (today's flow) and drops
+ *   the line from multi-service ones — the block shrinks from the tail
+ *   (duration derives from items), `serviceId` re-points if the primary line
+ *   fell, that line's inventory hold is released, and customers get a "tu
+ *   cita se actualizó" notification.
+ *
+ * The sweep scans the shop's FUTURE active appointments via
+ * `by_barbershopId_and_date` (a multi-line cita may not carry this service in
+ * its denormalized `serviceId`, so `by_serviceId` can't see it). Bounded per
+ * shop; if a mega-shop ever trips the 32k scanned-documents limit the mutation
+ * aborts atomically — port the paged self-rescheduling pattern from
+ * `barbershopCascade.ts` before raising any cap.
  */
 export const deleteService = zAuthMutation({
   args: z.object({
@@ -162,14 +179,16 @@ export const deleteService = zAuthMutation({
 
     const now = Date.now();
 
-    // Find impacted appointments: future/upcoming, not deleted, not cancelled/completed/no-show
-    const impactedAppointments = await ctx.db
+    // Future active citas referencing this service on ANY line. Legacy rows
+    // (no items) reference it iff their single `serviceId` matches.
+    const futureAppointments = await ctx.db
       .query("appointments")
-      .withIndex("by_serviceId", (q) => q.eq("serviceId", args.service.id))
+      .withIndex("by_barbershopId_and_date", (q) =>
+        q.eq("barbershopId", args.barbershop.id).gte("date", now),
+      )
       .filter((q) =>
         q.and(
           q.eq(q.field("deletedAt"), undefined),
-          q.gte(q.field("date"), now),
           q.or(
             q.eq(q.field("status"), "pending"),
             q.eq(q.field("status"), "confirmed"),
@@ -179,15 +198,39 @@ export const deleteService = zAuthMutation({
       )
       .collect();
 
-    // 2-step confirmation: if not force and impacted > 0, throw error with count
-    if (!args.force && impactedAppointments.length > 0) {
-      throw new ConvexError(`WILL_CANCEL:${impactedAppointments.length}`);
+    const cancelAppointments: Appointment[] = [];
+    const updateAppointments: Appointment[] = [];
+
+    for (const appt of futureAppointments) {
+      if (appt.items && appt.items.length > 0) {
+        if (!appt.items.some((line) => line.serviceId === args.service.id)) {
+          continue;
+        }
+
+        if (appt.items.length === 1) {
+          cancelAppointments.push(appt);
+        } else {
+          updateAppointments.push(appt);
+        }
+      } else if (appt.serviceId === args.service.id) {
+        cancelAppointments.push(appt);
+      }
+    }
+
+    // 2-step confirmation: if not force and anything is impacted, report both counts
+    if (
+      !args.force &&
+      (cancelAppointments.length > 0 || updateAppointments.length > 0)
+    ) {
+      throw new ConvexError(
+        `WILL_CANCEL:${cancelAppointments.length}:WILL_UPDATE:${updateAppointments.length}`,
+      );
     }
 
     // If force or no impacted appointments, proceed with deletion
     const barbershop = await ctx.db.get(args.barbershop.id);
 
-    for (const appt of impactedAppointments) {
+    for (const appt of cancelAppointments) {
       await releaseForAppointment(
         ctx,
         appt,
@@ -202,8 +245,24 @@ export const deleteService = zAuthMutation({
       });
     }
 
-    await Promise.all(
-      impactedAppointments.map((appt) =>
+    // Multi-service citas survive: drop the line (duration/total derive from
+    // items, so the block shrinks from the tail), re-point the denormalized
+    // primary if it fell, and free that line's inventory hold.
+    for (const appt of updateAppointments) {
+      const remaining = (appt.items ?? []).filter(
+        (line) => line.serviceId !== args.service.id,
+      );
+
+      await releaseServiceLineForAppointment(ctx, appt, args.service.id);
+
+      await ctx.db.patch(appt._id, {
+        items: remaining,
+        serviceId: remaining[0].serviceId,
+      });
+    }
+
+    await Promise.all([
+      ...cancelAppointments.map((appt) =>
         ctx.runMutation(
           internal.notifications.createServiceDeletedCancellation,
           {
@@ -216,7 +275,17 @@ export const deleteService = zAuthMutation({
           },
         ),
       ),
-    );
+      ...updateAppointments.map((appt) =>
+        ctx.runMutation(internal.notifications.createServiceLineRemoved, {
+          appointmentId: appt._id,
+          customerUserId: appt.userId,
+          serviceName: service.name,
+          barbershopName: barbershop?.name ?? "la barbería",
+          contactPhone: appt.contactPhone,
+          contactEmail: appt.contactEmail,
+        }),
+      ),
+    ]);
 
     // A deleted service takes its barber assignments and inventory recipe
     // with it (`services` cascade rules in cascade.ts).

--- a/convex/services.ts
+++ b/convex/services.ts
@@ -253,7 +253,12 @@ export const deleteService = zAuthMutation({
         (line) => line.serviceId !== args.service.id,
       );
 
-      await releaseServiceLineForAppointment(ctx, appt, args.service.id);
+      await releaseServiceLineForAppointment(
+        ctx,
+        appt,
+        args.service.id,
+        remaining.map((line) => line.serviceId),
+      );
 
       await ctx.db.patch(appt._id, {
         items: remaining,

--- a/emails/emails/appointments/appointment-updated.tsx
+++ b/emails/emails/appointments/appointment-updated.tsx
@@ -1,0 +1,54 @@
+import {
+    Body,
+    Container,
+    Head,
+    Html,
+    pixelBasedPreset,
+    Preview,
+    Tailwind,
+    Text,
+} from "react-email";
+
+import { tailwindConfig } from "../../tailwind-config";
+import { Header } from "../components/header";
+
+export interface AppointmentUpdatedEmailProps {
+  notes: string;
+  subject: string;
+  body: string;
+}
+
+export const AppointmentUpdatedEmail = ({
+  notes = "Se actualizaron los servicios de tu cita.",
+  subject = "Cita actualizada",
+  body,
+}: AppointmentUpdatedEmailProps) => {
+  return (
+    <Html lang="es" dir="ltr">
+      <Head />
+      <Preview>{subject} - PanaBarbero</Preview>
+      <Tailwind
+        config={{
+          presets: [pixelBasedPreset],
+          theme: tailwindConfig.theme,
+        }}
+      >
+        <Body className="bg-zinc-100 font-sans">
+          <Container className="mx-auto w-full max-w-md rounded-xl border border-border/50 bg-white p-4">
+            <Header />
+
+            <Text className="text-pretty">{body}</Text>
+
+            <Container className="mb-4 rounded-lg bg-muted p-4">
+              <Text className="m-0 mb-[8px] text-zinc-700 text-sm italic">
+                {notes}
+              </Text>
+            </Container>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};
+
+export default AppointmentUpdatedEmail;

--- a/emails/emails/index.tsx
+++ b/emails/emails/index.tsx
@@ -2,6 +2,7 @@ export * from "./appointments/appointment-cancelled";
 export * from "./appointments/appointment-created";
 export * from "./appointments/appointment-reminder";
 export * from "./appointments/appointment-reschedule-request";
+export * from "./appointments/appointment-updated";
 export * from "./appointments/past-appointment-reminder";
 export * from "./appointments/reschedule-request-accept";
 export * from "./appointments/reschedule-request-denied";

--- a/src/calendar/event-popover.tsx
+++ b/src/calendar/event-popover.tsx
@@ -116,7 +116,7 @@ export const EventPopover: FC<EventPopoverProps> = ({
 
             {needsMark ? (
               <MarkAppointmentDialog
-                appointmentId={appointment._id}
+                appointment={appointment}
                 trigger={
                   <Button variant="outline" size="sm" className="w-full">
                     Marcar cita

--- a/src/calendar/use-calendar-appointments.ts
+++ b/src/calendar/use-calendar-appointments.ts
@@ -10,6 +10,11 @@ import { useQueries } from "@tanstack/react-query";
 import { eachDayOfInterval, startOfDay } from "date-fns";
 import { useMemo } from "react";
 
+import {
+  appointmentItemsDuration,
+  appointmentItemsLabel,
+} from "@/lib/appointment-utils";
+
 import { eventEnd, getFetchRange } from "./helpers";
 import type { CalendarEvent, CalendarView } from "./types";
 
@@ -101,17 +106,23 @@ export function useCalendarAppointments({
           ) {
             continue;
           }
+          // Snapshot lines drive width/name when present; legacy rows keep
+          // the live-service join + FALLBACK_DURATION path.
           const service = serviceMap.get(appointment.serviceId);
           built.push({
             id: appointment._id,
             title: appointment.customerName,
             start: appointment.date,
-            end: eventEnd(appointment.date, service?.duration),
+            end: eventEnd(
+              appointment.date,
+              appointmentItemsDuration(appointment) ?? service?.duration,
+            ),
             status: appointment.status,
             barberId: appointment.barbershopMemberId,
             barberName:
               barberMap.get(appointment.barbershopMemberId) ?? "Barbero",
-            serviceName: service?.name ?? "Servicio",
+            serviceName:
+              appointmentItemsLabel(appointment) ?? service?.name ?? "Servicio",
             appointment,
           });
         }

--- a/src/components/appointments/appointment-card.tsx
+++ b/src/components/appointments/appointment-card.tsx
@@ -13,7 +13,10 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { getAppointmentDataByStatus } from "@/lib/appointment-utils";
+import {
+  appointmentItemsLabel,
+  getAppointmentDataByStatus,
+} from "@/lib/appointment-utils";
 
 const CancelAppointmentDialog = lazy(() =>
   import("./cancel-appointment-dialog").then((module) => ({
@@ -89,7 +92,7 @@ export const AppointmentCard: FC<AppointmentCardProps> = ({
       </CardHeader>
       <CardContent className="space-y-2">
         <p className="text-pretty text-muted-foreground text-sm">
-          Servicio: {service.name}
+          Servicio: {appointmentItemsLabel(appointment) ?? service.name}
         </p>
         <p className="text-pretty text-muted-foreground text-sm">
           {appointment.notes || "No hay notas"}

--- a/src/components/appointments/appointment-card.tsx
+++ b/src/components/appointments/appointment-card.tsx
@@ -15,8 +15,10 @@ import {
 } from "@/components/ui/card";
 import {
   appointmentItemsLabel,
+  appointmentItemsTotal,
   getAppointmentDataByStatus,
 } from "@/lib/appointment-utils";
+import { formatCurrency } from "@/lib/utils";
 
 const CancelAppointmentDialog = lazy(() =>
   import("./cancel-appointment-dialog").then((module) => ({
@@ -78,6 +80,13 @@ export const AppointmentCard: FC<AppointmentCardProps> = ({
 
   const { label, variant } = getAppointmentDataByStatus(appointment.status);
 
+  const itemsTotal = appointmentItemsTotal(appointment);
+  const totalLabel = itemsTotal
+    ? itemsTotal.isStarting
+      ? `Desde ${formatCurrency(itemsTotal.total)}`
+      : formatCurrency(itemsTotal.total)
+    : null;
+
   return (
     <Card className="max-h-full">
       <CardHeader>
@@ -94,6 +103,11 @@ export const AppointmentCard: FC<AppointmentCardProps> = ({
         <p className="text-pretty text-muted-foreground text-sm">
           Servicio: {appointmentItemsLabel(appointment) ?? service.name}
         </p>
+        {totalLabel && (
+          <p className="text-pretty text-muted-foreground text-sm tabular-nums">
+            Total: {totalLabel}
+          </p>
+        )}
         <p className="text-pretty text-muted-foreground text-sm">
           {appointment.notes || "No hay notas"}
         </p>

--- a/src/components/appointments/create-appointment-form.tsx
+++ b/src/components/appointments/create-appointment-form.tsx
@@ -178,7 +178,7 @@ export const CreateAppointmentForm: FC<CreateAppointmentFormProps> = ({
             notes: value.notes,
             barbershopId,
             barbershopMemberId,
-            serviceId: effectiveServiceId,
+            serviceIds: [effectiveServiceId],
             isStaffCreated: isBarber,
           },
         });
@@ -568,7 +568,7 @@ export const CreateAppointmentForm: FC<CreateAppointmentFormProps> = ({
                     barbershopMemberId={
                       barbershopMemberId as BarbershopMemberWithName["_id"]
                     }
-                    serviceId={effectiveServiceId}
+                    serviceIds={effectiveServiceId ? [effectiveServiceId] : []}
                     date={normalizedDate}
                     value={selectedSlotTime}
                     isPending={isPending}

--- a/src/components/appointments/create-appointment-form.tsx
+++ b/src/components/appointments/create-appointment-form.tsx
@@ -69,8 +69,8 @@ interface CreateAppointmentFormProps {
   barberServices?: Service[] | null;
   onBarberChange?: (barber: BarbershopMemberWithName) => void;
   showPhoneField?: boolean;
-  /** The resolved service ID (from store or prop) used for slot generation. */
-  effectiveServiceId?: Service["_id"];
+  /** The resolved service IDs (from the store) used for slot generation. */
+  effectiveServiceIds: Service["_id"][];
   initialValues: Partial<
     Pick<
       AppointmentFormValues,
@@ -106,7 +106,7 @@ export const CreateAppointmentForm: FC<CreateAppointmentFormProps> = ({
   onBarberChange,
   formIds,
   showPhoneField = false,
-  effectiveServiceId,
+  effectiveServiceIds,
   initialValues,
   onSuccess,
 }) => {
@@ -149,14 +149,17 @@ export const CreateAppointmentForm: FC<CreateAppointmentFormProps> = ({
     onSubmit: async ({ value }) => {
       const { date, barbershopMemberId, contactPhone } = value;
 
+      // `selectedSlotTime` gates against a stale time-of-day: slot resets
+      // (barber/service change) clear it while `date` may keep the old hour.
       if (
         date === undefined ||
+        !selectedSlotTime ||
         !barbershopMemberId ||
-        !effectiveServiceId ||
+        effectiveServiceIds.length === 0 ||
         !contactPhone
       ) {
         haptic.trigger("error");
-        toast.error("Selecciona servicio, barbero, fecha y hora.");
+        toast.error("Selecciona al menos un servicio, barbero, fecha y hora.");
         return;
       }
 
@@ -178,7 +181,7 @@ export const CreateAppointmentForm: FC<CreateAppointmentFormProps> = ({
             notes: value.notes,
             barbershopId,
             barbershopMemberId,
-            serviceIds: [effectiveServiceId],
+            serviceIds: effectiveServiceIds,
             isStaffCreated: isBarber,
           },
         });
@@ -218,7 +221,7 @@ export const CreateAppointmentForm: FC<CreateAppointmentFormProps> = ({
   // Reset the chosen slot when the barber or service changes (date reset handled
   // in calendar onSelect). Render-phase adjustment instead of an effect, to
   // avoid an extra render showing the stale slot.
-  const slotKey = `${form.state.values.barbershopMemberId ?? ""}|${effectiveServiceId ?? ""}`;
+  const slotKey = `${form.state.values.barbershopMemberId ?? ""}|${effectiveServiceIds.join(",")}`;
   const [prevSlotKey, setPrevSlotKey] = useState(slotKey);
   if (slotKey !== prevSlotKey) {
     setPrevSlotKey(slotKey);
@@ -542,7 +545,7 @@ export const CreateAppointmentForm: FC<CreateAppointmentFormProps> = ({
               const canShowSlots = !!(
                 date &&
                 barbershopMemberId &&
-                effectiveServiceId
+                effectiveServiceIds.length > 0
               );
               // Normalize to midnight so slot selection (which sets hours)
               // doesn't change query params
@@ -568,7 +571,7 @@ export const CreateAppointmentForm: FC<CreateAppointmentFormProps> = ({
                     barbershopMemberId={
                       barbershopMemberId as BarbershopMemberWithName["_id"]
                     }
-                    serviceIds={effectiveServiceId ? [effectiveServiceId] : []}
+                    serviceIds={effectiveServiceIds}
                     date={normalizedDate}
                     value={selectedSlotTime}
                     isPending={isPending}

--- a/src/components/appointments/customer-booking-form.tsx
+++ b/src/components/appointments/customer-booking-form.tsx
@@ -76,6 +76,8 @@ interface CustomerBookingFormProps {
   barbershop: Barbershop;
   services: Service[];
   barbers: BarbershopMemberWithName[];
+  /** Deep-linked `?serviceId=` match, rendered as selected until the store seeds. */
+  initialService?: Service;
 }
 
 interface BookingFormValues {
@@ -91,6 +93,7 @@ export const CustomerBookingForm: FC<CustomerBookingFormProps> = ({
   barbershop,
   services,
   barbers,
+  initialService,
 }) => {
   const barbershopUuid = barbershop.uuid;
   const navigate = useNavigate();
@@ -111,7 +114,19 @@ export const CustomerBookingForm: FC<CustomerBookingFormProps> = ({
   const { data: user } = useSession();
   const { data: userProfile } = useProfile(user?.id ?? "");
 
-  const selectedServices = useServicesStore();
+  const storeServices = useServicesStore();
+
+  // The store is client-only and seeds after mount, so SSR and the first
+  // hydrated frame fall back to the deep-linked service — same markup on both
+  // sides, and the fallback retires once the seed lands.
+  const [isStoreSeeded, setIsStoreSeeded] = useState(false);
+
+  useEffect(() => setIsStoreSeeded(true), []);
+
+  const selectedServices =
+    !isStoreSeeded && storeServices.length === 0 && initialService
+      ? [initialService]
+      : storeServices;
   const selectedServiceIds = selectedServices.map((service) => service._id);
   const selectedServiceIdSet = new Set(selectedServiceIds);
 

--- a/src/components/appointments/customer-booking-form.tsx
+++ b/src/components/appointments/customer-booking-form.tsx
@@ -208,8 +208,11 @@ export const CustomerBookingForm: FC<CustomerBookingFormProps> = ({
     onSubmit: async ({ value }) => {
       const { date, barbershopMemberId } = value;
 
+      // `selectedSlotTime` gates against a stale time-of-day: slot resets
+      // (barber/service change) clear it while `date` may keep the old hour.
       if (
         date === undefined ||
+        !selectedSlotTime ||
         !barbershopMemberId ||
         selectedServiceIds.length === 0
       ) {
@@ -878,8 +881,14 @@ export const CustomerBookingForm: FC<CustomerBookingFormProps> = ({
             const selectedBarberName =
               availableBarbers?.find((b) => b?._id === barberId)?.name ?? null;
 
+            // Until an hour is picked the date value is just the selected
+            // midnight, so formatting its time would show "12:00 a. m.".
             const appointmentDateTimeLabel =
-              date !== undefined ? formatLongDateTime(date) : null;
+              date !== undefined
+                ? selectedSlotTime
+                  ? formatLongDateTime(date)
+                  : `${formatLongDate(date)} · hora por definir`
+                : null;
 
             const timeRangeLabel =
               selectedSlotTime && totalDuration > 0

--- a/src/components/appointments/customer-booking-form.tsx
+++ b/src/components/appointments/customer-booking-form.tsx
@@ -50,7 +50,7 @@ import {
   useAppointmentActions,
   useAppointmentFormMetadata,
 } from "@/hooks/use-appointments";
-import { useBarbersForService } from "@/hooks/use-barbershop-members";
+import { useBarbersForServices } from "@/hooks/use-barbershop-members";
 import { useProfile } from "@/hooks/use-profile";
 import { useSession } from "@/hooks/use-session";
 import { getConvexErrorMessage } from "@/lib/convex-errors";
@@ -65,17 +65,17 @@ import {
   formatCurrency,
   formatLongDate,
   formatLongDateTime,
+  formatServicePrice,
   startOfDay,
   toDate,
 } from "@/lib/utils";
-import { setServiceStore, useServicesStore } from "@/store/services";
+import { toggleService, useServicesStore } from "@/store/services";
 import { TimeSlotPicker } from "./time-slot-picker";
 
 interface CustomerBookingFormProps {
   barbershop: Barbershop;
   services: Service[];
   barbers: BarbershopMemberWithName[];
-  initialServiceId?: Service["_id"];
 }
 
 interface BookingFormValues {
@@ -91,7 +91,6 @@ export const CustomerBookingForm: FC<CustomerBookingFormProps> = ({
   barbershop,
   services,
   barbers,
-  initialServiceId,
 }) => {
   const barbershopUuid = barbershop.uuid;
   const navigate = useNavigate();
@@ -112,16 +111,31 @@ export const CustomerBookingForm: FC<CustomerBookingFormProps> = ({
   const { data: user } = useSession();
   const { data: userProfile } = useProfile(user?.id ?? "");
 
-  const storeService = useServicesStore();
-  const effectiveServiceId = (storeService._id || initialServiceId) as
-    | Service["_id"]
-    | undefined;
+  const selectedServices = useServicesStore();
+  const selectedServiceIds = selectedServices.map((service) => service._id);
+  const selectedServiceIdSet = new Set(selectedServiceIds);
 
-  const { data: barbersForService } = useBarbersForService(effectiveServiceId);
+  const { data: barbersForServices } =
+    useBarbersForServices(selectedServiceIds);
 
-  const availableBarbers = effectiveServiceId
-    ? (barbersForService ?? barbers)
+  const availableBarbers = selectedServiceIds.length
+    ? (barbersForServices ?? barbers)
     : barbers;
+
+  const totalDuration = selectedServices.reduce(
+    (total, service) => total + service.duration,
+    0,
+  );
+  const totalPrice = selectedServices.reduce(
+    (total, service) => total + service.price,
+    0,
+  );
+  const hasStartingLine = selectedServices.some(
+    (service) => service.priceType === "starting",
+  );
+  const totalPriceLabel = hasStartingLine
+    ? `Desde ${formatCurrency(totalPrice)}`
+    : formatCurrency(totalPrice);
 
   const {
     createAppointment: {
@@ -179,9 +193,13 @@ export const CustomerBookingForm: FC<CustomerBookingFormProps> = ({
     onSubmit: async ({ value }) => {
       const { date, barbershopMemberId } = value;
 
-      if (date === undefined || !barbershopMemberId || !effectiveServiceId) {
+      if (
+        date === undefined ||
+        !barbershopMemberId ||
+        selectedServiceIds.length === 0
+      ) {
         haptic.trigger("error");
-        toast.error("Selecciona servicio, barbero, fecha y hora.");
+        toast.error("Selecciona al menos un servicio, barbero, fecha y hora.");
         return;
       }
 
@@ -203,7 +221,7 @@ export const CustomerBookingForm: FC<CustomerBookingFormProps> = ({
             notes: value.notes,
             barbershopId: barbershop._id,
             barbershopMemberId,
-            serviceId: effectiveServiceId,
+            serviceIds: selectedServiceIds,
             isStaffCreated: false,
           },
         });
@@ -305,21 +323,20 @@ export const CustomerBookingForm: FC<CustomerBookingFormProps> = ({
     }
   }, [availableBarbers, form]);
 
-  const effectiveService = services.find((s) => s._id === effectiveServiceId);
-
   // Barber changes reset the slot at the point of change (select handler /
-  // auto-select effect). Service changes need the same guard so the summary
-  // never shows a stale time for the newly selected service.
-  const previousServiceId = useRef(effectiveServiceId);
+  // auto-select effect). Selection changes need the same guard so the summary
+  // never shows a stale time for the newly selected services.
+  const serviceSelectionKey = selectedServiceIds.join("|");
+  const previousSelectionKey = useRef(serviceSelectionKey);
 
   useEffect(() => {
-    if (previousServiceId.current === effectiveServiceId) {
+    if (previousSelectionKey.current === serviceSelectionKey) {
       return;
     }
 
-    previousServiceId.current = effectiveServiceId;
+    previousSelectionKey.current = serviceSelectionKey;
     setSelectedSlotTime(undefined);
-  }, [effectiveServiceId]);
+  }, [serviceSelectionKey]);
 
   const pendingLabel = "Pendiente";
 
@@ -354,51 +371,55 @@ export const CustomerBookingForm: FC<CustomerBookingFormProps> = ({
                 No hay servicios disponibles.
               </span>
             ) : (
-              <Suspense fallback={<Skeleton className="h-11 w-full" />}>
-                <Select
-                  value={effectiveServiceId}
-                  onValueChange={(value) => {
-                    const match = services.find(
-                      (s) => String(s._id) === String(value),
-                    );
-                    if (match) {
-                      startTransition(() => {
-                        setServiceStore({ service: match });
-                      });
-                    }
-                  }}
-                >
-                  <SelectTrigger id={formIds.serviceId} className="h-11 w-full">
-                    <SelectValue placeholder="Seleccionar servicio...">
-                      {effectiveServiceId
-                        ? (services.find(
-                            (s) => String(s._id) === String(effectiveServiceId),
-                          )?.name ?? "Servicio no disponible")
-                        : undefined}
-                    </SelectValue>
-                  </SelectTrigger>
-                  <SelectContent>
-                    {services.map((service) => (
-                      <SelectItem key={service._id} value={service._id}>
-                        <div className="flex w-full items-center justify-between gap-2">
-                          <span className="font-medium">{service.name}</span>
-                          <div className="flex flex-col items-end text-muted-foreground text-xs">
-                            <span>{formatCurrency(service.price)}</span>
-                            <span>{service.duration} min</span>
-                          </div>
-                        </div>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </Suspense>
+              <fieldset
+                id={formIds.serviceId}
+                aria-labelledby="booking-service-heading"
+                className="flex flex-col gap-2"
+              >
+                {services.map((service) => {
+                  const checked = selectedServiceIdSet.has(service._id);
+                  const rowId = `${formIds.serviceId}-${service._id}`;
+
+                  return (
+                    <div
+                      key={service._id}
+                      className={cn(
+                        "flex items-center gap-3 rounded-lg border p-3 transition-colors",
+                        checked
+                          ? "border-primary/50 bg-primary/5"
+                          : "hover:bg-muted/40",
+                      )}
+                    >
+                      <Checkbox
+                        id={rowId}
+                        checked={checked}
+                        onCheckedChange={() => {
+                          startTransition(() => {
+                            toggleService(service);
+                          });
+                        }}
+                      />
+                      <FieldLabel
+                        htmlFor={rowId}
+                        className="flex flex-1 cursor-pointer items-center justify-between gap-3"
+                      >
+                        <span className="font-medium text-sm">
+                          {service.name}
+                        </span>
+                        <span className="flex flex-col items-end text-muted-foreground text-xs">
+                          <span>{formatServicePrice(service)}</span>
+                          <span>{service.duration} min</span>
+                        </span>
+                      </FieldLabel>
+                    </div>
+                  );
+                })}
+              </fieldset>
             )}
-            {effectiveService && (
+            {selectedServices.length > 0 && (
               <div className="flex flex-wrap gap-2 pt-2">
-                <Badge variant="secondary">
-                  {formatCurrency(effectiveService.price)}
-                </Badge>
-                <Badge variant="outline">{effectiveService.duration} min</Badge>
+                <Badge variant="secondary">{totalPriceLabel}</Badge>
+                <Badge variant="outline">{totalDuration} min</Badge>
               </div>
             )}
           </Field>
@@ -416,7 +437,9 @@ export const CustomerBookingForm: FC<CustomerBookingFormProps> = ({
 
                 {availableBarbers?.length === 0 ? (
                   <span className="text-muted-foreground text-sm">
-                    No hay barberos disponibles para este servicio.
+                    {selectedServiceIds.length > 1
+                      ? "Ningún barbero ofrece todos los servicios seleccionados."
+                      : "No hay barberos disponibles para este servicio."}
                   </span>
                 ) : availableBarbers?.length === 1 ? (
                   <div className="flex items-center gap-3 rounded-lg border bg-muted/30 p-3">
@@ -710,7 +733,7 @@ export const CustomerBookingForm: FC<CustomerBookingFormProps> = ({
                       dateValue &&
                       normalizedDate &&
                       barberId &&
-                      effectiveServiceId
+                      selectedServiceIds.length > 0
                     ) {
                       return (
                         <Suspense
@@ -728,7 +751,7 @@ export const CustomerBookingForm: FC<CustomerBookingFormProps> = ({
                           <TimeSlotPicker
                             barbershopId={barbershop._id}
                             barbershopMemberId={barberId}
-                            serviceId={effectiveServiceId}
+                            serviceIds={selectedServiceIds}
                             date={normalizedDate}
                             value={selectedSlotTime}
                             isPending={isPending}
@@ -749,7 +772,7 @@ export const CustomerBookingForm: FC<CustomerBookingFormProps> = ({
                       ? "Selecciona una fecha para ver los horarios disponibles."
                       : !barberId
                         ? "Elige un barbero para cargar sus horarios."
-                        : "Elige un servicio para ver la disponibilidad.";
+                        : "Elige al menos un servicio para ver la disponibilidad.";
 
                     return (
                       <div className="rounded-lg border border-border/60 bg-background/50 px-3 py-6 text-center">
@@ -844,11 +867,11 @@ export const CustomerBookingForm: FC<CustomerBookingFormProps> = ({
               date !== undefined ? formatLongDateTime(date) : null;
 
             const timeRangeLabel =
-              selectedSlotTime && effectiveService
+              selectedSlotTime && totalDuration > 0
                 ? `${selectedSlotTime} – ${addMinutesToTime(
                     selectedSlotTime,
-                    effectiveService.duration,
-                  )} (${effectiveService.duration} min)`
+                    totalDuration,
+                  )} (${totalDuration} min)`
                 : null;
 
             const phoneSummaryRaw = contactPhone?.trim() ?? "";
@@ -870,20 +893,36 @@ export const CustomerBookingForm: FC<CustomerBookingFormProps> = ({
                   </div>
                   <div className="min-w-0">
                     <CardDescription className="text-xs">
-                      Servicio
+                      {selectedServices.length > 1 ? "Servicios" : "Servicio"}
                     </CardDescription>
-                    <p
-                      className={cn(
-                        "mt-0.5 text-sm",
-                        effectiveService
-                          ? "font-medium text-foreground"
-                          : "text-muted-foreground",
-                      )}
-                    >
-                      {effectiveService
-                        ? `${effectiveService.name} · ${formatCurrency(effectiveService.price)} · ${effectiveService.duration} min`
-                        : pendingLabel}
-                    </p>
+                    {selectedServices.length > 0 ? (
+                      <div className="mt-0.5 space-y-0.5">
+                        {selectedServices.map((service) => (
+                          <p
+                            key={service._id}
+                            className="font-medium text-foreground text-sm"
+                          >
+                            {service.name} · {formatServicePrice(service)} ·{" "}
+                            {service.duration} min
+                          </p>
+                        ))}
+                        {selectedServices.length > 1 && (
+                          <p className="text-muted-foreground text-xs">
+                            Total: {totalPriceLabel} · {totalDuration} min
+                          </p>
+                        )}
+                        {hasStartingLine && (
+                          <p className="text-muted-foreground text-xs">
+                            El precio final se define al finalizar el servicio;
+                            mínimo {formatCurrency(totalPrice)}.
+                          </p>
+                        )}
+                      </div>
+                    ) : (
+                      <p className="mt-0.5 text-muted-foreground text-sm">
+                        {pendingLabel}
+                      </p>
+                    )}
                   </div>
                   <div className="min-w-0">
                     <CardDescription className="text-xs">

--- a/src/components/appointments/delete-appointment-form.tsx
+++ b/src/components/appointments/delete-appointment-form.tsx
@@ -90,7 +90,7 @@ export const CancelAppointmentForm: FC<CancelAppointmentFormProps> = ({
 
       <form.AppForm>
         <form.SubmitButton
-          label="Si, cancelar"
+          label="Sí, cancelar"
           variant="destructive"
           className="w-full"
         />

--- a/src/components/appointments/mark-appointment-dialog.tsx
+++ b/src/components/appointments/mark-appointment-dialog.tsx
@@ -1,4 +1,4 @@
-import type { Appointment } from "@convex/schema";
+import type { Appointment, AppointmentItem } from "@convex/schema";
 import type { FC, ReactElement, SubmitEvent } from "react";
 import { useId, useState } from "react";
 import { toast } from "sonner";
@@ -6,6 +6,7 @@ import { useWebHaptics } from "web-haptics/react";
 
 import { Button } from "@/components/ui/button";
 import { Field } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
@@ -19,60 +20,21 @@ import {
 } from "@/components/ui/responsive-modal";
 import { useAppointmentActions } from "@/hooks/use-appointments";
 import { getConvexErrorMessage } from "@/lib/convex-errors";
+import { cn, formatCurrency } from "@/lib/utils";
 
 interface MarkAppointmentDialogProps {
   trigger: ReactElement;
-  appointmentId: Appointment["_id"];
+  appointment: Appointment;
 }
 
 export const MarkAppointmentDialog: FC<MarkAppointmentDialogProps> = ({
   trigger,
-  appointmentId,
+  appointment,
 }) => {
   const [open, setOpen] = useState<boolean>(false);
+  const [status, setStatus] = useState<"completed" | "no-show">("completed");
+  const [finalPrices, setFinalPrices] = useState<Record<string, string>>({});
   const formId = useId();
-
-  const title = "Marcar cita";
-  const description = "Asigna el estado final de la cita.";
-
-  return (
-    <ResponsiveModal open={open} onOpenChange={setOpen}>
-      <ResponsiveModalTrigger render={trigger} />
-      <ResponsiveModalContent className="pb-4">
-        <ResponsiveModalHeader>
-          <ResponsiveModalTitle>{title}</ResponsiveModalTitle>
-          <ResponsiveModalDescription>{description}</ResponsiveModalDescription>
-        </ResponsiveModalHeader>
-
-        <OptionsForm
-          appointmentId={appointmentId}
-          formId={formId}
-          onClose={() => setOpen(false)}
-        />
-
-        <ResponsiveModalFooter>
-          <Field>
-            <Button type="submit" form={formId}>
-              Marcar
-            </Button>
-          </Field>
-        </ResponsiveModalFooter>
-      </ResponsiveModalContent>
-    </ResponsiveModal>
-  );
-};
-
-interface OptionsFormProps {
-  appointmentId: Appointment["_id"];
-  formId: string;
-  onClose: () => void;
-}
-
-const OptionsForm: FC<OptionsFormProps> = ({
-  appointmentId,
-  formId,
-  onClose,
-}) => {
   const formIds = {
     completed: useId(),
     noShow: useId(),
@@ -80,47 +42,145 @@ const OptionsForm: FC<OptionsFormProps> = ({
   const haptic = useWebHaptics();
 
   const {
-    setStatusMutation: { mutateAsync: setStatus },
+    setStatusMutation: { mutateAsync: setAppointmentStatus },
   } = useAppointmentActions();
+
+  // "Starting" lines need their agreed final price to complete; legacy rows
+  // (no items) never carry starting lines, so the dialog stays as-is for them.
+  const startingLines = (appointment.items ?? []).filter(
+    (line) => line.priceType === "starting" && line.finalPrice === undefined,
+  );
+
+  const requiresFinalPrices =
+    status === "completed" && startingLines.length > 0;
+
+  const isLineValid = (line: AppointmentItem) => {
+    const value = Number(finalPrices[line.serviceId]);
+
+    return Number.isFinite(value) && value >= line.price;
+  };
+
+  const submitDisabled =
+    requiresFinalPrices && !startingLines.every(isLineValid);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (nextOpen) {
+      setStatus("completed");
+      setFinalPrices(
+        Object.fromEntries(
+          startingLines.map((line) => [line.serviceId, String(line.price)]),
+        ),
+      );
+    }
+    setOpen(nextOpen);
+  };
 
   const onSubmit = async (e: SubmitEvent<HTMLFormElement>) => {
     e.preventDefault();
     e.stopPropagation();
 
-    const formData = new FormData(e.target as HTMLFormElement);
-    const status = formData.get("status") as "completed" | "no-show";
-
     try {
-      onClose();
+      setOpen(false);
 
-      await setStatus({
-        appointment: { id: appointmentId },
+      await setAppointmentStatus({
+        appointment: { id: appointment._id },
         status,
+        finalPrices: requiresFinalPrices
+          ? startingLines.map((line) => ({
+              serviceId: line.serviceId,
+              finalPrice: Number(finalPrices[line.serviceId]),
+            }))
+          : undefined,
       });
 
       haptic.trigger("success");
       toast.success("Cita marcada correctamente.");
-
-      return;
     } catch (error) {
       haptic.trigger("error");
       toast.error(getConvexErrorMessage(error));
-      return;
     }
   };
 
   return (
-    <form id={formId} className="flex gap-4" onSubmit={onSubmit}>
-      <RadioGroup defaultValue="completed" name="status">
-        <div className="flex items-center gap-3">
-          <RadioGroupItem value="completed" id={formIds.completed} />
-          <Label htmlFor={formIds.completed}>Completada</Label>
-        </div>
-        <div className="flex items-center gap-3">
-          <RadioGroupItem value="no-show" id={formIds.noShow} />
-          <Label htmlFor={formIds.noShow}>No asistió</Label>
-        </div>
-      </RadioGroup>
-    </form>
+    <ResponsiveModal open={open} onOpenChange={handleOpenChange}>
+      <ResponsiveModalTrigger render={trigger} />
+      <ResponsiveModalContent className="pb-4">
+        <ResponsiveModalHeader>
+          <ResponsiveModalTitle>Marcar cita</ResponsiveModalTitle>
+          <ResponsiveModalDescription>
+            Asigna el estado final de la cita.
+          </ResponsiveModalDescription>
+        </ResponsiveModalHeader>
+
+        <form id={formId} className="flex flex-col gap-4" onSubmit={onSubmit}>
+          <RadioGroup
+            value={status}
+            onValueChange={(value) =>
+              setStatus(value as "completed" | "no-show")
+            }
+            name="status"
+          >
+            <div className="flex items-center gap-3">
+              <RadioGroupItem value="completed" id={formIds.completed} />
+              <Label htmlFor={formIds.completed}>Completada</Label>
+            </div>
+            <div className="flex items-center gap-3">
+              <RadioGroupItem value="no-show" id={formIds.noShow} />
+              <Label htmlFor={formIds.noShow}>No asistió</Label>
+            </div>
+          </RadioGroup>
+
+          {requiresFinalPrices && (
+            <div className="flex flex-col gap-3">
+              <p className="text-muted-foreground text-sm">
+                Registra el precio final acordado para los servicios con precio
+                "desde".
+              </p>
+              {startingLines.map((line) => {
+                const invalid = !isLineValid(line);
+                const inputId = `${formId}-${line.serviceId}`;
+
+                return (
+                  <Field key={line.serviceId} data-invalid={invalid}>
+                    <Label htmlFor={inputId}>{line.name}</Label>
+                    <Input
+                      id={inputId}
+                      type="number"
+                      inputMode="numeric"
+                      min={line.price}
+                      value={finalPrices[line.serviceId] ?? ""}
+                      onChange={(e) =>
+                        setFinalPrices((prev) => ({
+                          ...prev,
+                          [line.serviceId]: e.target.value,
+                        }))
+                      }
+                      aria-invalid={invalid}
+                      className="tabular-nums"
+                    />
+                    <p
+                      className={cn(
+                        "text-xs",
+                        invalid ? "text-destructive" : "text-muted-foreground",
+                      )}
+                    >
+                      Mínimo {formatCurrency(line.price)}.
+                    </p>
+                  </Field>
+                );
+              })}
+            </div>
+          )}
+        </form>
+
+        <ResponsiveModalFooter>
+          <Field>
+            <Button type="submit" form={formId} disabled={submitDisabled}>
+              Marcar
+            </Button>
+          </Field>
+        </ResponsiveModalFooter>
+      </ResponsiveModalContent>
+    </ResponsiveModal>
   );
 };

--- a/src/components/appointments/reschedule-request-form.tsx
+++ b/src/components/appointments/reschedule-request-form.tsx
@@ -31,7 +31,13 @@ import {
 import { getConvexErrorMessage } from "@/lib/convex-errors";
 import { validateAppointmentTime } from "@/lib/schedule-utils";
 import { rescheduleRequestFormSchema } from "@/lib/schemas";
-import { cn, formatLongDate, formatTimeOfDay, toDate } from "@/lib/utils";
+import {
+  cn,
+  formatLongDate,
+  formatTimeOfDay,
+  startOfDay,
+  toDate,
+} from "@/lib/utils";
 
 interface RescheduleRequestFormProps {
   appointment: Appointment;
@@ -170,6 +176,12 @@ export const RescheduleRequestForm: FC<RescheduleRequestFormProps> = ({
               message?: string;
             }>;
             const isInvalid = errors.length > 0;
+            // Stable per selected day; only a day change remounts the time
+            // input below (time edits keep the same key).
+            const timeInputDayKey =
+              field.state.value === undefined
+                ? "no-day"
+                : startOfDay(field.state.value).getTime();
 
             return (
               <>
@@ -234,7 +246,13 @@ export const RescheduleRequestForm: FC<RescheduleRequestFormProps> = ({
                       type="time"
                       id={timeId}
                       suppressHydrationWarning
-                      value={timeInputValue(field.state.value)}
+                      // Uncontrolled on purpose: a controlled value clobbers
+                      // in-progress segment typing whenever a partial edit is
+                      // ignored below. The day key remounts it (with the
+                      // carried time) when a different day is picked.
+                      key={timeInputDayKey}
+                      defaultValue={timeInputValue(field.state.value)}
+                      step={300}
                       disabled={field.state.value === undefined}
                       onChange={(e) => {
                         const time = e.target.value;

--- a/src/components/appointments/table/columns.tsx
+++ b/src/components/appointments/table/columns.tsx
@@ -6,6 +6,7 @@ import { lazy } from "react";
 import { DataTableColumnHeader } from "@/components/table/data-table-column-header";
 import { Button } from "@/components/ui/button";
 import { useServiceByAppointmentId } from "@/hooks/use-services";
+import { appointmentItemsLabel } from "@/lib/appointment-utils";
 
 const RescheduleResponseDialog = lazy(() =>
   import("../reschedule-response-dialog").then((module) => ({
@@ -13,11 +14,10 @@ const RescheduleResponseDialog = lazy(() =>
   })),
 );
 
-const ServiceNameCell: FC<{ appointmentId: Appointment["_id"] }> = ({
-  appointmentId,
-}) => {
-  const { data: service } = useServiceByAppointmentId(appointmentId);
-  return <span>{service?.name}</span>;
+const ServiceNameCell: FC<{ appointment: Appointment }> = ({ appointment }) => {
+  // Legacy rows (no snapshot lines) still resolve the live service.
+  const { data: service } = useServiceByAppointmentId(appointment._id);
+  return <span>{appointmentItemsLabel(appointment) ?? service?.name}</span>;
 };
 
 const formatDateTime = (ms: number) =>
@@ -49,7 +49,7 @@ export const rescheduledAppointmentRequestsTableColumns: ColumnDef<
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Servicio" />
     ),
-    cell: ({ row }) => <ServiceNameCell appointmentId={row.original._id} />,
+    cell: ({ row }) => <ServiceNameCell appointment={row.original} />,
   },
   {
     accessorKey: "date",

--- a/src/components/appointments/table/columns.tsx
+++ b/src/components/appointments/table/columns.tsx
@@ -14,10 +14,22 @@ const RescheduleResponseDialog = lazy(() =>
   })),
 );
 
-const ServiceNameCell: FC<{ appointment: Appointment }> = ({ appointment }) => {
-  // Legacy rows (no snapshot lines) still resolve the live service.
+const LegacyServiceNameCell: FC<{ appointment: Appointment }> = ({
+  appointment,
+}) => {
   const { data: service } = useServiceByAppointmentId(appointment._id);
-  return <span>{appointmentItemsLabel(appointment) ?? service?.name}</span>;
+  return <span>{service?.name}</span>;
+};
+
+const ServiceNameCell: FC<{ appointment: Appointment }> = ({ appointment }) => {
+  const label = appointmentItemsLabel(appointment);
+
+  // Only legacy rows (no snapshot lines) need the live-service subscription.
+  return label ? (
+    <span>{label}</span>
+  ) : (
+    <LegacyServiceNameCell appointment={appointment} />
+  );
 };
 
 const formatDateTime = (ms: number) =>

--- a/src/components/appointments/time-slot-picker.tsx
+++ b/src/components/appointments/time-slot-picker.tsx
@@ -8,7 +8,8 @@ import { cn } from "@/lib/utils";
 interface TimeSlotPickerProps {
   barbershopId: Barbershop["_id"];
   barbershopMemberId: BarbershopMember["_id"];
-  serviceId: Service["_id"];
+  /** Selected services — the slot width is the sum of their durations. */
+  serviceIds: Service["_id"][];
   /** Midnight-normalized timestamp of the selected date. */
   date: number;
   /** Currently selected slot time string (e.g. "09:00"). */
@@ -21,7 +22,7 @@ interface TimeSlotPickerProps {
 export const TimeSlotPicker: FC<TimeSlotPickerProps> = ({
   barbershopId,
   barbershopMemberId,
-  serviceId,
+  serviceIds,
   date,
   value,
   isPending,
@@ -30,7 +31,7 @@ export const TimeSlotPicker: FC<TimeSlotPickerProps> = ({
   const { data: slots } = useAvailableSlots({
     barbershopId,
     barbershopMemberId,
-    serviceId,
+    serviceIds,
     date,
   });
 

--- a/src/components/barbershops/services/columns.tsx
+++ b/src/components/barbershops/services/columns.tsx
@@ -3,7 +3,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 
 import { DataTableColumnHeader } from "@/components/table/data-table-column-header";
 import { DataTableRowActions } from "@/components/table/data-table-row-actions";
-import { formatCurrency } from "@/lib/utils";
+import { formatServicePrice } from "@/lib/utils";
 
 export type ServiceRow = Service;
 
@@ -47,7 +47,7 @@ export function getServicesTableColumns(
       ),
       cell: ({ row }) => (
         <div className="text-right tabular-nums">
-          {formatCurrency(row.original.price)}
+          {formatServicePrice(row.original)}
         </div>
       ),
     },

--- a/src/components/barbershops/services/delete-service-dialog.tsx
+++ b/src/components/barbershops/services/delete-service-dialog.tsx
@@ -27,13 +27,31 @@ interface DeleteServiceDialogProps {
   onOpenChange?: (open: boolean) => void;
 }
 
+interface DeleteServiceImpact {
+  /** Citas whose ONLY service is this one — they get cancelled. */
+  cancelCount: number;
+  /** Multi-service citas — they lose this line but survive. */
+  updateCount: number;
+}
+
 /**
- * Parses the "WILL_CANCEL:N" error message from the backend.
- * Returns the appointment count if matched, otherwise null.
+ * Parses the "WILL_CANCEL:N:WILL_UPDATE:M" error message from the backend
+ * (the ":WILL_UPDATE:M" suffix is absent on messages from older deploys).
+ * Returns the impact counts if matched, otherwise null.
  */
-function parseWillCancelError(errorMessage: string): number | null {
-  const match = errorMessage.match(/WILL_CANCEL:(\d+)/);
-  return match ? Number.parseInt(match[1], 10) : null;
+function parseWillCancelError(
+  errorMessage: string,
+): DeleteServiceImpact | null {
+  const match = errorMessage.match(/WILL_CANCEL:(\d+)(?::WILL_UPDATE:(\d+))?/);
+
+  if (!match) {
+    return null;
+  }
+
+  return {
+    cancelCount: Number.parseInt(match[1], 10),
+    updateCount: match[2] ? Number.parseInt(match[2], 10) : 0,
+  };
 }
 
 export const DeleteServiceDialog: FC<DeleteServiceDialogProps> = ({
@@ -51,7 +69,10 @@ export const DeleteServiceDialog: FC<DeleteServiceDialogProps> = ({
   const [confirmationStep, setConfirmationStep] = useState<
     "initial" | "confirm_cancellation"
   >("initial");
-  const [impactedCount, setImpactedCount] = useState<number>(0);
+  const [impact, setImpact] = useState<DeleteServiceImpact>({
+    cancelCount: 0,
+    updateCount: 0,
+  });
 
   const {
     deleteServiceMutation: {
@@ -66,7 +87,7 @@ export const DeleteServiceDialog: FC<DeleteServiceDialogProps> = ({
     onOpenChange?.(newOpen);
     if (!newOpen) {
       setConfirmationStep("initial");
-      setImpactedCount(0);
+      setImpact({ cancelCount: 0, updateCount: 0 });
     }
   };
 
@@ -83,10 +104,10 @@ export const DeleteServiceDialog: FC<DeleteServiceDialogProps> = ({
       handleOpenChange(false);
     } catch (error) {
       const errorMessage = getConvexErrorMessage(error);
-      const willCancelCount = parseWillCancelError(errorMessage);
+      const parsedImpact = parseWillCancelError(errorMessage);
 
-      if (willCancelCount !== null && !force) {
-        setImpactedCount(willCancelCount);
+      if (parsedImpact !== null && !force) {
+        setImpact(parsedImpact);
         setConfirmationStep("confirm_cancellation");
       } else {
         haptic.trigger("error");
@@ -99,15 +120,30 @@ export const DeleteServiceDialog: FC<DeleteServiceDialogProps> = ({
 
   const dialogTitle = isInitialStep
     ? "Eliminar servicio"
-    : "Confirmar cancelación de citas";
+    : "Confirmar cambios en citas";
+
+  const impactSummary = [
+    impact.cancelCount > 0
+      ? `${impact.cancelCount} cita(s) solo incluyen este servicio y serán canceladas`
+      : null,
+    impact.updateCount > 0
+      ? `${impact.updateCount} cita(s) lo combinan con otros servicios y se actualizarán (se quita este servicio; el resto de la cita sigue confirmada)`
+      : null,
+  ]
+    .filter(Boolean)
+    .join(". ");
 
   const dialogDescription = isInitialStep
     ? "¿Estás seguro que deseas eliminar este servicio? Esta acción no se puede deshacer."
-    : `Este servicio tiene ${impactedCount} cita(s) pendiente(s) que serán canceladas. Los clientes serán notificados.`;
+    : `${impactSummary}. Los clientes serán notificados.`;
 
   const buttonLabel = isInitialStep
     ? "Sí, eliminar"
-    : `Eliminar y cancelar ${impactedCount} cita(s)`;
+    : impact.cancelCount > 0 && impact.updateCount > 0
+      ? `Eliminar (cancela ${impact.cancelCount}, actualiza ${impact.updateCount})`
+      : impact.updateCount > 0
+        ? `Eliminar y actualizar ${impact.updateCount} cita(s)`
+        : `Eliminar y cancelar ${impact.cancelCount} cita(s)`;
 
   return (
     <ResponsiveModal open={open} onOpenChange={handleOpenChange}>

--- a/src/components/barbershops/services/service-form.tsx
+++ b/src/components/barbershops/services/service-form.tsx
@@ -44,14 +44,15 @@ export const ServiceForm: FC<ServiceFormProps> = ({
       // @ts-expect-error - convex id schema is not supported by tanstack form
       onSubmit: initialValues ? services.updateSchema : services.insertSchema,
     },
-    defaultValues: initialValues
-      ? initialValues
-      : {
-          name: "",
-          price: 1000,
-          duration: 5,
-          barbershopId: barbershopId,
-        },
+    defaultValues:
+      initialValues ??
+      ({
+        name: "",
+        price: 1000,
+        duration: 5,
+        priceType: "fixed",
+        barbershopId: barbershopId,
+      } as ServiceFormData),
     onSubmit: async ({ value }) => {
       try {
         if (serviceId) {
@@ -61,6 +62,7 @@ export const ServiceForm: FC<ServiceFormProps> = ({
               name: value.name,
               price: Number(value.price),
               duration: Number(value.duration),
+              priceType: value.priceType ?? "fixed",
               barbershopId: barbershopId,
             },
           });
@@ -74,6 +76,7 @@ export const ServiceForm: FC<ServiceFormProps> = ({
             name: value.name,
             price: Number(value.price),
             duration: Number(value.duration),
+            priceType: value.priceType ?? "fixed",
             barbershopId: barbershopId,
           });
 
@@ -141,6 +144,28 @@ export const ServiceForm: FC<ServiceFormProps> = ({
             )}
           </form.AppField>
         </div>
+
+        <form.AppField name="priceType">
+          {(field) => (
+            <field.RadioGroupField
+              label="Tipo de precio"
+              options={[
+                {
+                  value: "fixed",
+                  label: "Precio fijo",
+                  description:
+                    "El cliente paga exactamente el precio publicado.",
+                },
+                {
+                  value: "starting",
+                  label: "Precio desde (mínimo)",
+                  description:
+                    'Se muestra como "Desde $X". El precio final se acuerda con el cliente y se registra al completar la cita.',
+                },
+              ]}
+            />
+          )}
+        </form.AppField>
       </FieldGroup>
 
       <form.AppForm>

--- a/src/components/barbershops/services/services-dropdown.tsx
+++ b/src/components/barbershops/services/services-dropdown.tsx
@@ -18,7 +18,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn, formatServicePrice } from "@/lib/utils";
-import { useServicesStoreActions } from "@/store/services";
+import { useServicesStore, useServicesStoreActions } from "@/store/services";
 
 interface ServicesDropdownProps {
   services: Service[] | undefined;
@@ -26,9 +26,17 @@ interface ServicesDropdownProps {
 
 export const ServicesDropdown: FC<ServicesDropdownProps> = ({ services }) => {
   const [open, setOpen] = useState<boolean>(false);
-  const [value, setValue] = useState("");
 
-  const { setServiceStore } = useServicesStoreActions();
+  const selectedServices = useServicesStore();
+  const selectedIds = new Set(selectedServices.map((service) => service._id));
+  const { toggleService } = useServicesStoreActions();
+
+  const triggerLabel =
+    selectedServices.length === 0
+      ? "Seleccionar servicios..."
+      : selectedServices.length === 1
+        ? selectedServices[0]?.name
+        : `${selectedServices.length} servicios`;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -43,9 +51,7 @@ export const ServicesDropdown: FC<ServicesDropdownProps> = ({ services }) => {
             aria-controls="services-listbox"
             className="w-full justify-between"
           >
-            {services && value
-              ? services.find((service) => service._id === value)?.name
-              : "Seleccionar servicio..."}
+            {triggerLabel}
             <CaretUpDownIcon className="opacity-50" />
           </Button>
         }
@@ -60,15 +66,9 @@ export const ServicesDropdown: FC<ServicesDropdownProps> = ({ services }) => {
                 <CommandItem
                   key={service._id}
                   value={service._id}
-                  onSelect={(currentValue) => {
-                    setValue(currentValue === value ? "" : currentValue);
-                    setOpen(false);
-                    setServiceStore({
-                      service: {
-                        ...service,
-                      },
-                    });
-                  }}
+                  // The popover stays open so several services can be toggled
+                  // in one visit; it closes on outside click / escape.
+                  onSelect={() => toggleService(service)}
                 >
                   {service.name}
                   <span className="ml-auto text-muted-foreground text-xs">
@@ -77,7 +77,9 @@ export const ServicesDropdown: FC<ServicesDropdownProps> = ({ services }) => {
                   <CheckIcon
                     className={cn(
                       "size-3",
-                      value === service._id ? "opacity-100" : "opacity-0",
+                      selectedIds.has(service._id)
+                        ? "opacity-100"
+                        : "opacity-0",
                     )}
                   />
                 </CommandItem>

--- a/src/components/barbershops/services/services-dropdown.tsx
+++ b/src/components/barbershops/services/services-dropdown.tsx
@@ -17,7 +17,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { cn } from "@/lib/utils";
+import { cn, formatServicePrice } from "@/lib/utils";
 import { useServicesStoreActions } from "@/store/services";
 
 interface ServicesDropdownProps {
@@ -71,9 +71,12 @@ export const ServicesDropdown: FC<ServicesDropdownProps> = ({ services }) => {
                   }}
                 >
                   {service.name}
+                  <span className="ml-auto text-muted-foreground text-xs">
+                    {formatServicePrice(service)}
+                  </span>
                   <CheckIcon
                     className={cn(
-                      "ml-auto size-3",
+                      "size-3",
                       value === service._id ? "opacity-100" : "opacity-0",
                     )}
                   />

--- a/src/components/barbershops/services/services-grid.tsx
+++ b/src/components/barbershops/services/services-grid.tsx
@@ -23,17 +23,19 @@ export const ServicesGrid: FC<ServicesGridProps> = ({
       <div className="grid gap-2 md:grid-cols-2 lg:grid-cols-3">
         {services.map((service) => (
           <div
-            className="flex min-w-0 items-center justify-between p-4"
+            className="grid min-w-0 grid-rows-[1fr_auto] gap-3 p-4"
             key={service._id}
           >
-            <div className="min-w-0">
-              <p className="truncate font-medium text-sm">{service.name}</p>
+            <div className="flex flex-col items-start justify-between gap-2 lg:flex-row lg:items-center">
+              <p className="wrap-break-word font-medium text-sm leading-snug">
+                {service.name}
+              </p>
               <p className="text-muted-foreground text-xs">
                 {service.duration} min
               </p>
             </div>
 
-            <div className="flex shrink-0 items-center gap-3">
+            <div className="flex items-center justify-between gap-3">
               <span className="font-semibold text-sm tabular-nums">
                 {formatCurrency(service.price)}
               </span>

--- a/src/components/barbershops/services/services-grid.tsx
+++ b/src/components/barbershops/services/services-grid.tsx
@@ -4,7 +4,7 @@ import type { FC } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { formatCurrency } from "@/lib/utils";
+import { formatServicePrice } from "@/lib/utils";
 
 interface ServicesGridProps {
   services: Service[];
@@ -37,7 +37,7 @@ export const ServicesGrid: FC<ServicesGridProps> = ({
 
             <div className="flex items-center justify-between gap-3">
               <span className="font-semibold text-sm tabular-nums">
-                {formatCurrency(service.price)}
+                {formatServicePrice(service)}
               </span>
 
               <Button

--- a/src/components/chat/chat-view.tsx
+++ b/src/components/chat/chat-view.tsx
@@ -1,5 +1,6 @@
 import { ChatCircleIcon, CrownIcon } from "@phosphor-icons/react";
 import { Link } from "@tanstack/react-router";
+import { ConvexError } from "convex/values";
 import type { ChangeEvent, FormEvent } from "react";
 import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -30,6 +31,16 @@ import {
   useSendChatMessage,
 } from "@/hooks/use-chat";
 import { useSession } from "@/hooks/use-session";
+import { getConvexErrorMessage } from "@/lib/convex-errors";
+
+/** ConvexError → its `data` copy; other Errors → their message as-is. */
+function chatErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof ConvexError) {
+    return getConvexErrorMessage(error);
+  }
+
+  return error instanceof Error ? error.message : fallback;
+}
 
 const SUGGESTIONS = [
   "¿Qué barberías hay cerca?",
@@ -96,11 +107,7 @@ export function ChatView({ threadId, routeScope = "public" }: ChatViewProps) {
       try {
         await send(threadId, trimmed);
       } catch (error) {
-        toast.error(
-          error instanceof Error
-            ? error.message
-            : "No se pudo enviar el mensaje.",
-        );
+        toast.error(chatErrorMessage(error, "No se pudo enviar el mensaje."));
       } finally {
         setIsSending(false);
       }
@@ -137,11 +144,7 @@ export function ChatView({ threadId, routeScope = "public" }: ChatViewProps) {
       try {
         await handleConfirm(proposal);
       } catch (error) {
-        toast.error(
-          error instanceof Error
-            ? error.message
-            : "No se pudo completar la acción.",
-        );
+        toast.error(chatErrorMessage(error, "No se pudo completar la acción."));
         // Re-throw so the card resets its in-flight state and keeps the buttons.
         throw error;
       }
@@ -153,11 +156,7 @@ export function ChatView({ threadId, routeScope = "public" }: ChatViewProps) {
     try {
       await handleReject();
     } catch (error) {
-      toast.error(
-        error instanceof Error
-          ? error.message
-          : "No se pudo cancelar la acción.",
-      );
+      toast.error(chatErrorMessage(error, "No se pudo cancelar la acción."));
       throw error;
     }
   }, [handleReject]);

--- a/src/components/chat/proposal-card.tsx
+++ b/src/components/chat/proposal-card.tsx
@@ -1,8 +1,12 @@
 import { CheckIcon, SpinnerIcon, XIcon } from "@phosphor-icons/react";
-import { useCallback, useState } from "react";
+import { useCallback, useId, useState } from "react";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { Field } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn, formatCurrency } from "@/lib/utils";
 
 const PROPOSAL_KIND = "needs-confirmation" as const;
 
@@ -25,6 +29,24 @@ export const proposalSchema = z.object({
 
 export type Proposal = z.infer<typeof proposalSchema>;
 
+/**
+ * The one exception to the loose-args rule: completing a cita with "desde"
+ * lines needs their agreed final prices, which only the user can supply. The
+ * proposal ships the pending lines; the card collects one final price each and
+ * sends them back as `finalPrices` (re-validated server-side by `setStatus`).
+ */
+const completionFinalsSchema = z.object({
+  status: z.literal("completed"),
+  startingLines: z
+    .object({
+      serviceId: z.string(),
+      name: z.string(),
+      minimumPrice: z.number(),
+    })
+    .array()
+    .min(1),
+});
+
 interface ProposalCardProps {
   proposal: Proposal;
   /**
@@ -46,6 +68,34 @@ export function ProposalCard({
   onReject,
 }: ProposalCardProps) {
   const [submitting, setSubmitting] = useState(false);
+  const inputIdPrefix = useId();
+
+  const completionFinals =
+    proposal.action === "manageAppointment"
+      ? completionFinalsSchema.safeParse(proposal.args)
+      : undefined;
+  const startingLines = completionFinals?.success
+    ? completionFinals.data.startingLines
+    : undefined;
+
+  const [finalPrices, setFinalPrices] = useState<Record<string, string>>(() =>
+    Object.fromEntries(
+      (startingLines ?? []).map((line) => [
+        line.serviceId,
+        String(line.minimumPrice),
+      ]),
+    ),
+  );
+
+  const isLineValid = (line: { serviceId: string; minimumPrice: number }) => {
+    const value = Number(finalPrices[line.serviceId]);
+
+    return Number.isFinite(value) && value >= line.minimumPrice;
+  };
+
+  const finalsInvalid = Boolean(
+    startingLines && !startingLines.every(isLineValid),
+  );
 
   const handleConfirm = useCallback(async () => {
     setSubmitting(true);
@@ -53,11 +103,24 @@ export function ProposalCard({
       // On success the action appends its confirmation message, so this card
       // stops being the last message and the buttons disappear on their own.
       // On failure the parent toasts and we re-enable the buttons for a retry.
-      await onConfirm(proposal);
+      await onConfirm(
+        startingLines
+          ? {
+              ...proposal,
+              args: {
+                ...(proposal.args as Record<string, unknown>),
+                finalPrices: startingLines.map((line) => ({
+                  serviceId: line.serviceId,
+                  finalPrice: Number(finalPrices[line.serviceId]),
+                })),
+              },
+            }
+          : proposal,
+      );
     } catch {
       setSubmitting(false);
     }
-  }, [proposal, onConfirm]);
+  }, [proposal, onConfirm, startingLines, finalPrices]);
 
   const handleReject = useCallback(async () => {
     setSubmitting(true);
@@ -73,6 +136,44 @@ export function ProposalCard({
       <AlertDescription className="text-sm leading-relaxed">
         {proposal.summary}
       </AlertDescription>
+      {isActive && startingLines && (
+        <div className="flex flex-col gap-3">
+          {startingLines.map((line) => {
+            const invalid = !isLineValid(line);
+            const inputId = `${inputIdPrefix}-${line.serviceId}`;
+
+            return (
+              <Field key={line.serviceId} data-invalid={invalid}>
+                <Label htmlFor={inputId}>{line.name}</Label>
+                <Input
+                  id={inputId}
+                  type="number"
+                  inputMode="numeric"
+                  min={line.minimumPrice}
+                  value={finalPrices[line.serviceId] ?? ""}
+                  onChange={(e) =>
+                    setFinalPrices((prev) => ({
+                      ...prev,
+                      [line.serviceId]: e.target.value,
+                    }))
+                  }
+                  aria-invalid={invalid}
+                  disabled={submitting}
+                  className="tabular-nums"
+                />
+                <p
+                  className={cn(
+                    "text-xs",
+                    invalid ? "text-destructive" : "text-muted-foreground",
+                  )}
+                >
+                  Mínimo {formatCurrency(line.minimumPrice)}.
+                </p>
+              </Field>
+            );
+          })}
+        </div>
+      )}
       {isActive && (
         <div className="flex items-center justify-end gap-2">
           <Button
@@ -87,7 +188,7 @@ export function ProposalCard({
           </Button>
           <Button
             className="h-8"
-            disabled={submitting}
+            disabled={submitting || finalsInvalid}
             onClick={handleConfirm}
             size="sm"
           >

--- a/src/components/notifications/notification-renderer.tsx
+++ b/src/components/notifications/notification-renderer.tsx
@@ -48,6 +48,7 @@ export const NotificationRenderer: FC<NotificationRendererProps> = ({
     case "appointment_reschedule_denied":
     case "barber_removed_cancellation":
     case "service_deleted_cancellation":
+    case "service_line_removed":
       return <CancellationNotification {...shared} kind={notification.kind} />;
 
     case "appointment_reschedule_request":

--- a/src/components/notifications/variants/cancellation-notification.tsx
+++ b/src/components/notifications/variants/cancellation-notification.tsx
@@ -32,6 +32,11 @@ const config = {
     icon: <WarningCircleIcon weight="duotone" />,
     actionLabel: "Ver citas",
   },
+  service_line_removed: {
+    tone: "warning" as const,
+    icon: <WarningCircleIcon weight="duotone" />,
+    actionLabel: "Ver citas",
+  },
 };
 
 export const CancellationNotification: FC<

--- a/src/hooks/use-appointments.ts
+++ b/src/hooks/use-appointments.ts
@@ -61,7 +61,7 @@ export function useAppointmentsByBarbershop(opts: {
 function availableSlotsQueryOptions(opts: {
   barbershopId: Barbershop["_id"];
   barbershopMemberId: BarbershopMember["_id"];
-  serviceId: Service["_id"];
+  serviceIds: Service["_id"][];
   date: number;
 }) {
   return convexQuery(api.appointments.getAvailableSlots, opts);
@@ -70,7 +70,7 @@ function availableSlotsQueryOptions(opts: {
 export function useAvailableSlots(opts: {
   barbershopId: Barbershop["_id"];
   barbershopMemberId: BarbershopMember["_id"];
-  serviceId: Service["_id"];
+  serviceIds: Service["_id"][];
   date: number;
 }) {
   return useSuspenseQuery(availableSlotsQueryOptions(opts));

--- a/src/hooks/use-barbershop-members.ts
+++ b/src/hooks/use-barbershop-members.ts
@@ -99,6 +99,16 @@ export function useBarbersForService(serviceId: Service["_id"] | undefined) {
   );
 }
 
+/** Barbers assigned to ALL selected services (multi-service booking). */
+export function useBarbersForServices(serviceIds: Service["_id"][]) {
+  return useQuery(
+    convexQuery(
+      api.barbershopMemberServices.getBarbersForServices,
+      serviceIds.length > 0 ? { serviceIds } : "skip",
+    ),
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Barber schedule
 // ---------------------------------------------------------------------------

--- a/src/lib/appointment-utils.ts
+++ b/src/lib/appointment-utils.ts
@@ -67,6 +67,29 @@ export function appointmentItemsLabel(appointment: Appointment): string | null {
   return appointment.items.map((item) => item.name).join(" + ");
 }
 
+/**
+ * Σ(finalPrice ?? price) over the snapshot lines — the appointment's effective
+ * total; null for legacy rows. `isStarting` marks a total that still has a
+ * pending "desde" line, so it should read as "Desde $X".
+ */
+export function appointmentItemsTotal(
+  appointment: Appointment,
+): { total: number; isStarting: boolean } | null {
+  if (!appointment.items || appointment.items.length === 0) {
+    return null;
+  }
+
+  return {
+    total: appointment.items.reduce(
+      (total, item) => total + (item.finalPrice ?? item.price),
+      0,
+    ),
+    isStarting: appointment.items.some(
+      (item) => item.priceType === "starting" && item.finalPrice === undefined,
+    ),
+  };
+}
+
 /** Summed snapshot duration in minutes; null for legacy rows. */
 export function appointmentItemsDuration(
   appointment: Appointment,

--- a/src/lib/appointment-utils.ts
+++ b/src/lib/appointment-utils.ts
@@ -57,3 +57,23 @@ export function getAppointmentDataByStatus(status: Appointment["status"]) {
     variant: getAppointmentStatusBadgeVariant(status),
   };
 }
+
+/** Joined snapshot line names ("Corte + Barba"); null for legacy rows. */
+export function appointmentItemsLabel(appointment: Appointment): string | null {
+  if (!appointment.items || appointment.items.length === 0) {
+    return null;
+  }
+
+  return appointment.items.map((item) => item.name).join(" + ");
+}
+
+/** Summed snapshot duration in minutes; null for legacy rows. */
+export function appointmentItemsDuration(
+  appointment: Appointment,
+): number | null {
+  if (!appointment.items || appointment.items.length === 0) {
+    return null;
+  }
+
+  return appointment.items.reduce((total, item) => total + item.duration, 0);
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -112,6 +112,7 @@ const serviceFormSchema = object({
     .max(480, {
       message: "La duración del servicio debe ser menor a 8 horas",
     }),
+  priceType: zodEnum(["fixed", "starting"]).optional(),
   barbershopId: zodAny(),
 });
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -342,6 +342,16 @@ export function formatCurrency(amount: number, currency = "COP"): string {
   return currencyFormatter.format(amount);
 }
 
+/** "Desde COP 15.000" for starting-price services; the plain price otherwise. */
+export function formatServicePrice(service: {
+  price: number;
+  priceType?: "fixed" | "starting";
+}): string {
+  const price = formatCurrency(service.price);
+
+  return service.priceType === "starting" ? `Desde ${price}` : price;
+}
+
 const longDateFormatter = new Intl.DateTimeFormat("es-CO", {
   day: "2-digit",
   month: "long",

--- a/src/routes/_authedRoutes/profile/barbershops/appointments/index.tsx
+++ b/src/routes/_authedRoutes/profile/barbershops/appointments/index.tsx
@@ -46,10 +46,12 @@ import {
   barberByUserIdQueryOptions,
   barbershopMembersByBarbershopIdQueryOptions,
   isBarberQueryOptions,
+  isOwnerQueryOptions,
   isStaffQueryOptions,
   servicesForBarberQueryOptions,
   useBarbershopMembersByBarbershopId,
   useIsBarber,
+  useIsOwner,
   useIsStaff,
 } from "@/hooks/use-barbershop-members";
 import {
@@ -107,6 +109,7 @@ export const Route = createFileRoute(
       context.queryClient.ensureQueryData(barberByUserIdQueryOptions(userId)),
       context.queryClient.ensureQueryData(isBarberQueryOptions(userId)),
       context.queryClient.ensureQueryData(isStaffQueryOptions(userId)),
+      context.queryClient.ensureQueryData(isOwnerQueryOptions(userId)),
       context.queryClient.ensureQueryData(
         barbershopAvailabilityQueryOptions(barbershopId),
       ),
@@ -117,7 +120,9 @@ export const Route = createFileRoute(
       context.queryClient.ensureQueryData(
         requestRescheduleQueryOptions(barbershopId),
       ),
-    ]).then(([, , , , , , members, requests]) => [members, requests] as const);
+    ]).then(
+      ([, , , , , , , members, requests]) => [members, requests] as const,
+    );
 
     // Calendar range: one day-windowed query per visible day, matching
     // useCalendarAppointments' fan-out so the grid paints without pop-in.
@@ -165,10 +170,11 @@ function RouteComponent() {
   const { canCreateStaffAppointments } = useBarbershopPlan(barbershop?._id!);
   const { data: isBarber } = useIsBarber(session?.id ?? "");
   const { data: isStaff } = useIsStaff(session?.id ?? "");
+  const { data: isOwner } = useIsOwner(session?.id ?? "");
 
-  const isOwner = session?.id ? barbershop?.ownerId === session.id : false;
   const canManage = isStaff || isOwner;
-  const canCreate = canCreateStaffAppointments && (isBarber || isStaff);
+  const canCreate =
+    canCreateStaffAppointments && (isBarber || isStaff || isOwner);
 
   const rescheduleTable = useDataTable({
     data: rescheduledAppointmentRequests,

--- a/src/routes/_authedRoutes/profile/barbershops/appointments/index.tsx
+++ b/src/routes/_authedRoutes/profile/barbershops/appointments/index.tsx
@@ -49,6 +49,7 @@ import {
   isOwnerQueryOptions,
   isStaffQueryOptions,
   servicesForBarberQueryOptions,
+  useBarberByUserId,
   useBarbershopMembersByBarbershopId,
   useIsBarber,
   useIsOwner,
@@ -171,13 +172,23 @@ function RouteComponent() {
   const { data: isBarber } = useIsBarber(session?.id ?? "");
   const { data: isStaff } = useIsStaff(session?.id ?? "");
   const { data: isOwner } = useIsOwner(session?.id ?? "");
+  const { data: currentBarberMember } = useBarberByUserId(session?.id ?? "");
 
   const canManage = isStaff || isOwner;
   const canCreate =
     canCreateStaffAppointments && (isBarber || isStaff || isOwner);
 
+  // Barbers without a management role only handle their own appointments, so
+  // they only see their own reschedule requests.
+  const visibleRescheduleRequests =
+    isBarber && !canManage
+      ? rescheduledAppointmentRequests.filter(
+          (request) => request.barbershopMemberId === currentBarberMember?._id,
+        )
+      : rescheduledAppointmentRequests;
+
   const rescheduleTable = useDataTable({
-    data: rescheduledAppointmentRequests,
+    data: visibleRescheduleRequests,
     columns: rescheduledAppointmentRequestsTableColumns,
     pageSize: 10,
   });

--- a/src/routes/_authedRoutes/profile/barbershops/appointments/new/index.tsx
+++ b/src/routes/_authedRoutes/profile/barbershops/appointments/new/index.tsx
@@ -41,7 +41,7 @@ import {
   isStaffQueryOptions,
   servicesForBarberQueryOptions,
   useBarberByUserId,
-  useBarbersForService,
+  useBarbersForServices,
   useBarbershopMembersByBarbershopId,
   useIsBarber,
   useIsOwner,
@@ -54,8 +54,8 @@ import {
   useServicesByBarbershopId,
 } from "@/hooks/use-services";
 import { useSession } from "@/hooks/use-session";
-import { formatServicePrice } from "@/lib/utils";
-import { useServicesStore } from "@/store/services";
+import { formatCurrency, formatServicePrice } from "@/lib/utils";
+import { resetServiceStore, useServicesStore } from "@/store/services";
 
 const searchSchema = z.object({
   date: z.number().optional(),
@@ -134,14 +134,20 @@ function RouteComponent() {
   const { data: currentBarberMember } = useBarberByUserId(userId);
 
   const storeServices = useServicesStore();
-  const effectiveServiceId = storeServices[0]?._id as
-    | Service["_id"]
-    | undefined;
-  const { data: barbersForService } = useBarbersForService(effectiveServiceId);
+  const effectiveServiceIds = storeServices.map(
+    (nextService) => nextService._id as Service["_id"],
+  );
+  const { data: barbersForServices } =
+    useBarbersForServices(effectiveServiceIds);
   const [selectedBarber, setSelectedBarber] = useState<
     BarbershopMemberWithName | undefined
   >(undefined);
   const { data: barberServices } = useServicesForBarber(selectedBarber?._id);
+
+  // The selection store is shared with the public booking flow; reset it on
+  // unmount so a staff selection never leaks into the next flow (or vice
+  // versa).
+  useEffect(() => () => resetServiceStore(), []);
 
   const isCreatingOnBehalf = isBarber || isStaff || isOwner;
   const showPhoneField =
@@ -149,12 +155,23 @@ function RouteComponent() {
   const allBarbers = barbershopMembers.filter((member) =>
     member.roles.includes("barber"),
   );
-  const availableBarbers = effectiveServiceId
-    ? (barbersForService ?? allBarbers)
+  const availableBarbers = effectiveServiceIds.length
+    ? (barbersForServices ?? allBarbers)
     : allBarbers;
-  const selectedService = services.find(
-    (nextService) => nextService._id === effectiveServiceId,
+  const totalDuration = storeServices.reduce(
+    (total, nextService) => total + nextService.duration,
+    0,
   );
+  const totalPrice = storeServices.reduce(
+    (total, nextService) => total + nextService.price,
+    0,
+  );
+  const hasStartingLine = storeServices.some(
+    (nextService) => nextService.priceType === "starting",
+  );
+  const totalPriceLabel = hasStartingLine
+    ? `Desde ${formatCurrency(totalPrice)}`
+    : formatCurrency(totalPrice);
   const defaultBarberId =
     isBarber && !isStaff
       ? currentBarberMember?._id
@@ -227,7 +244,7 @@ function RouteComponent() {
                 (nextService) => nextService !== null,
               )}
               onBarberChange={setSelectedBarber}
-              effectiveServiceId={effectiveServiceId}
+              effectiveServiceIds={effectiveServiceIds}
               showPhoneField={showPhoneField}
               disabledFields={
                 isCreatingOnBehalf
@@ -275,26 +292,31 @@ function RouteComponent() {
               </CardHeader>
               <CardContent className="space-y-3">
                 <dl className="grid gap-2 text-sm">
-                  <div className="flex items-center justify-between gap-3">
-                    <dt className="text-muted-foreground">Servicio</dt>
-                    <dd className="max-w-40 truncate font-medium">
-                      {selectedService?.name ?? "Sin seleccionar"}
+                  <div className="flex items-start justify-between gap-3">
+                    <dt className="text-muted-foreground">
+                      {storeServices.length > 1 ? "Servicios" : "Servicio"}
+                    </dt>
+                    <dd className="max-w-40 space-y-0.5 text-right font-medium">
+                      {storeServices.length > 0
+                        ? storeServices.map((nextService) => (
+                            <p key={nextService._id} className="truncate">
+                              {nextService.name} ·{" "}
+                              {formatServicePrice(nextService)}
+                            </p>
+                          ))
+                        : "Sin seleccionar"}
                     </dd>
                   </div>
                   <div className="flex items-center justify-between gap-3">
                     <dt className="text-muted-foreground">Duración</dt>
                     <dd className="font-medium tabular-nums">
-                      {selectedService
-                        ? `${selectedService.duration} min`
-                        : "—"}
+                      {storeServices.length > 0 ? `${totalDuration} min` : "—"}
                     </dd>
                   </div>
                   <div className="flex items-center justify-between gap-3">
                     <dt className="text-muted-foreground">Precio</dt>
                     <dd className="font-medium tabular-nums">
-                      {selectedService
-                        ? formatServicePrice(selectedService)
-                        : "—"}
+                      {storeServices.length > 0 ? totalPriceLabel : "—"}
                     </dd>
                   </div>
                   <div className="flex items-center justify-between gap-3">

--- a/src/routes/_authedRoutes/profile/barbershops/appointments/new/index.tsx
+++ b/src/routes/_authedRoutes/profile/barbershops/appointments/new/index.tsx
@@ -37,12 +37,14 @@ import {
   barberByUserIdQueryOptions,
   barbershopMembersByBarbershopIdQueryOptions,
   isBarberQueryOptions,
+  isOwnerQueryOptions,
   isStaffQueryOptions,
   servicesForBarberQueryOptions,
   useBarberByUserId,
   useBarbersForService,
   useBarbershopMembersByBarbershopId,
   useIsBarber,
+  useIsOwner,
   useIsStaff,
   useServicesForBarber,
 } from "@/hooks/use-barbershop-members";
@@ -80,6 +82,7 @@ export const Route = createFileRoute(
 
     const isBarber = roles?.roles?.includes("barber") ?? false;
     const isStaff = roles?.isStaff ?? false;
+    const isOwner = roles?.isOwner ?? false;
 
     const plan = await context.queryClient.ensureQueryData(
       getBarbershopPlanQueryOptions(barbershop._id),
@@ -87,7 +90,7 @@ export const Route = createFileRoute(
 
     if (
       !plan?.planLimits.staffCanCreateAppointments ||
-      (!isBarber && !isStaff)
+      (!isBarber && !isStaff && !isOwner)
     ) {
       throw redirect({ to: "/profile/barbershops/appointments" });
     }
@@ -99,6 +102,7 @@ export const Route = createFileRoute(
       context.queryClient.ensureQueryData(barberByUserIdQueryOptions(userId)),
       context.queryClient.ensureQueryData(isBarberQueryOptions(userId)),
       context.queryClient.ensureQueryData(isStaffQueryOptions(userId)),
+      context.queryClient.ensureQueryData(isOwnerQueryOptions(userId)),
       context.queryClient.ensureQueryData(
         barbershopAvailabilityQueryOptions(barbershop._id),
       ),
@@ -126,6 +130,7 @@ function RouteComponent() {
   const { data: services } = useServicesByBarbershopId(barbershop?._id!);
   const { data: isBarber } = useIsBarber(userId);
   const { data: isStaff } = useIsStaff(userId);
+  const { data: isOwner } = useIsOwner(userId);
   const { data: currentBarberMember } = useBarberByUserId(userId);
 
   const storeServices = useServicesStore();
@@ -138,7 +143,7 @@ function RouteComponent() {
   >(undefined);
   const { data: barberServices } = useServicesForBarber(selectedBarber?._id);
 
-  const isCreatingOnBehalf = isBarber || isStaff;
+  const isCreatingOnBehalf = isBarber || isStaff || isOwner;
   const showPhoneField =
     isCreatingOnBehalf || (!isCreatingOnBehalf && !userProfile?.phoneNumber);
   const allBarbers = barbershopMembers.filter((member) =>
@@ -167,10 +172,13 @@ function RouteComponent() {
   }, [isBarber, isStaff, currentBarberMember, barbershopMembers]);
 
   useEffect(() => {
-    if (availableBarbers.length === 1 && (!isCreatingOnBehalf || isStaff)) {
+    if (
+      availableBarbers.length === 1 &&
+      (!isCreatingOnBehalf || isStaff || (isOwner && !isBarber))
+    ) {
       setSelectedBarber(availableBarbers[0]!);
     }
-  }, [isCreatingOnBehalf, isStaff, availableBarbers]);
+  }, [isCreatingOnBehalf, isStaff, isOwner, isBarber, availableBarbers]);
 
   const formIds = {
     customerName: useId(),

--- a/src/routes/_authedRoutes/profile/barbershops/appointments/new/index.tsx
+++ b/src/routes/_authedRoutes/profile/barbershops/appointments/new/index.tsx
@@ -52,7 +52,7 @@ import {
   useServicesByBarbershopId,
 } from "@/hooks/use-services";
 import { useSession } from "@/hooks/use-session";
-import { formatCurrency } from "@/lib/utils";
+import { formatServicePrice } from "@/lib/utils";
 import { useServicesStore } from "@/store/services";
 
 const searchSchema = z.object({
@@ -128,8 +128,10 @@ function RouteComponent() {
   const { data: isStaff } = useIsStaff(userId);
   const { data: currentBarberMember } = useBarberByUserId(userId);
 
-  const service = useServicesStore();
-  const effectiveServiceId = service._id as Service["_id"] | undefined;
+  const storeServices = useServicesStore();
+  const effectiveServiceId = storeServices[0]?._id as
+    | Service["_id"]
+    | undefined;
   const { data: barbersForService } = useBarbersForService(effectiveServiceId);
   const [selectedBarber, setSelectedBarber] = useState<
     BarbershopMemberWithName | undefined
@@ -283,7 +285,7 @@ function RouteComponent() {
                     <dt className="text-muted-foreground">Precio</dt>
                     <dd className="font-medium tabular-nums">
                       {selectedService
-                        ? formatCurrency(selectedService.price)
+                        ? formatServicePrice(selectedService)
                         : "—"}
                     </dd>
                   </div>

--- a/src/routes/_authedRoutes/profile/barbershops/services/index.tsx
+++ b/src/routes/_authedRoutes/profile/barbershops/services/index.tsx
@@ -147,6 +147,7 @@ const ServicesDashboard: FC<ServicesDashboardProps> = ({
             name: dialog.row.name,
             price: dialog.row.price,
             duration: dialog.row.duration,
+            priceType: dialog.row.priceType ?? "fixed",
             barbershopId,
           }
         : undefined,

--- a/src/routes/barbershops/$barbershopUuid/book.tsx
+++ b/src/routes/barbershops/$barbershopUuid/book.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowLeftIcon } from "@phosphor-icons/react";
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
-import { lazy, Suspense, useEffect, useMemo } from "react";
+import { lazy, Suspense, useEffect, useMemo, useRef } from "react";
 import { z } from "zod";
 
 import { BorderContainer } from "@/components/layout/border-container";
@@ -113,12 +113,22 @@ function RouteComponent() {
     [barbershopMembers],
   );
 
-  // Initialize the services store from the URL search param
+  // Deep-linked service, resolved during render so SSR and the first hydrated
+  // frame show it selected (the store below only fills in after mount).
+  const initialService = useMemo(
+    () => (serviceId ? services?.find((s) => s._id === serviceId) : undefined),
+    [serviceId, services],
+  );
+
+  // Seed the store once: `services` is live query data, and re-running this
+  // would wipe a selection the customer made after landing.
+  const hasSeededStore = useRef(false);
+
   useEffect(() => {
-    if (!serviceId || !services?.length) return;
-    const match = services.find((s) => s._id === serviceId);
-    if (match) setServiceStore({ service: match });
-  }, [serviceId, services]);
+    if (hasSeededStore.current || !initialService) return;
+    hasSeededStore.current = true;
+    setServiceStore({ service: initialService });
+  }, [initialService]);
 
   // Reset store on unmount to prevent stale state leaking into other contexts
   useEffect(() => {
@@ -171,6 +181,7 @@ function RouteComponent() {
                   barbershop={barbershop}
                   services={services ?? EMPTY_MEMBERS}
                   barbers={barbers}
+                  initialService={initialService}
                 />
               </Suspense>
             </section>

--- a/src/routes/barbershops/$barbershopUuid/book.tsx
+++ b/src/routes/barbershops/$barbershopUuid/book.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowLeftIcon } from "@phosphor-icons/react";
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
-import { lazy, Suspense, useEffect, useMemo, useRef } from "react";
+import { lazy, Suspense, useEffect, useMemo } from "react";
 import { z } from "zod";
 
 import { BorderContainer } from "@/components/layout/border-container";
@@ -30,7 +30,7 @@ import {
 } from "@/hooks/use-services";
 import { useSession } from "@/hooks/use-session";
 import { cn } from "@/lib/utils";
-import { resetServiceStore, setServiceStore } from "@/store/services";
+import { resetServiceStore, seedServiceStore } from "@/store/services";
 
 const CustomerBookingForm = lazy(() =>
   import("@/components/appointments/customer-booking-form").then((module) => ({
@@ -120,14 +120,11 @@ function RouteComponent() {
     [serviceId, services],
   );
 
-  // Seed the store once: `services` is live query data, and re-running this
-  // would wipe a selection the customer made after landing.
-  const hasSeededStore = useRef(false);
-
+  // The seed only writes while the selection is empty, so the route's dev
+  // double-mount (whose first cleanup resets the store after the first seed)
+  // and live `services` refetches can re-run it without clobbering anything.
   useEffect(() => {
-    if (hasSeededStore.current || !initialService) return;
-    hasSeededStore.current = true;
-    setServiceStore({ service: initialService });
+    if (initialService) seedServiceStore(initialService);
   }, [initialService]);
 
   // Reset store on unmount to prevent stale state leaking into other contexts

--- a/src/routes/barbershops/$barbershopUuid/book.tsx
+++ b/src/routes/barbershops/$barbershopUuid/book.tsx
@@ -171,9 +171,6 @@ function RouteComponent() {
                   barbershop={barbershop}
                   services={services ?? EMPTY_MEMBERS}
                   barbers={barbers}
-                  initialServiceId={
-                    serviceId as (typeof services)[0]["_id"] | undefined
-                  }
                 />
               </Suspense>
             </section>

--- a/src/store/services/index.ts
+++ b/src/store/services/index.ts
@@ -8,9 +8,20 @@ interface ServicesStore {
 
 const servicesStore = new Store<ServicesStore>({ services: [] });
 
-/** Replace the selection with a single service (staff dropdown, URL seed). */
+/** Replace the selection with a single service (staff dropdown). */
 export function setServiceStore({ service }: { service: Service }) {
   servicesStore.setState(() => ({ services: [service] }));
+}
+
+/**
+ * URL seed: fills the selection only while it is still empty, so re-running
+ * (route double-mounts, live `services` refetches) never clobbers what the
+ * customer picked.
+ */
+export function seedServiceStore(service: Service) {
+  servicesStore.setState((state) =>
+    state.services.length > 0 ? state : { services: [service] },
+  );
 }
 
 /** Multi-select toggle: add if absent, remove if present; order kept. */

--- a/src/store/services/index.ts
+++ b/src/store/services/index.ts
@@ -1,46 +1,42 @@
-import type { Barbershop, Service } from "@convex/schema";
+import type { Service } from "@convex/schema";
 import { Store, useStore } from "@tanstack/react-store";
 
 interface ServicesStore {
-  service: Service;
+  /** Selected services, in selection order (no duplicates). */
+  services: Service[];
 }
 
-const servicesStore = new Store<ServicesStore>({
-  service: {
-    _creationTime: 0,
-    _id: "" as unknown as Service["_id"],
-    barbershopId: "" as unknown as Barbershop["_id"],
-    name: "",
-    price: 0,
-    duration: 0,
-  },
-});
+const servicesStore = new Store<ServicesStore>({ services: [] });
 
-const emptyService: Service = {
-  _creationTime: 0,
-  _id: "" as unknown as Service["_id"],
-  barbershopId: "" as unknown as Barbershop["_id"],
-  name: "",
-  price: 0,
-  duration: 0,
-};
+/** Replace the selection with a single service (staff dropdown, URL seed). */
+export function setServiceStore({ service }: { service: Service }) {
+  servicesStore.setState(() => ({ services: [service] }));
+}
 
-export function setServiceStore({ service }: ServicesStore) {
-  servicesStore.setState(() => ({
-    service,
-  }));
+/** Multi-select toggle: add if absent, remove if present; order kept. */
+export function toggleService(service: Service) {
+  servicesStore.setState((state) => {
+    const exists = state.services.some((s) => s._id === service._id);
+
+    return {
+      services: exists
+        ? state.services.filter((s) => s._id !== service._id)
+        : [...state.services, service],
+    };
+  });
 }
 
 export function resetServiceStore() {
-  servicesStore.setState(() => ({ service: emptyService }));
+  servicesStore.setState(() => ({ services: [] }));
 }
 
 export function useServicesStore() {
-  return useStore(servicesStore, (state) => state.service);
+  return useStore(servicesStore, (state) => state.services);
 }
 
 export function useServicesStoreActions() {
   return {
     setServiceStore,
+    toggleService,
   };
 }


### PR DESCRIPTION
## Summary

- Add canonical appointment line items for multi-service bookings, duration/conflict math, inventory holds, analytics, and legacy-row backfill.
- Support `Desde` service pricing with required final prices at completion and snapshot-based totals/labels.
- Update booking, calendar, service management, notifications, and AI booking flows for multiple services.
- Add the Pullfrog manual review workflow and document the appointment pricing model.

## Testing

- Not run (not provided).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Book appointments with multiple services, including combined duration, pricing, availability, and barber matching.
  * Support “Desde” pricing and enter final prices when completing applicable appointments.
  * Display clearer service names, prices, totals, and durations across booking, calendar, and appointment views.
* **Bug Fixes**
  * Deleting a service preserves remaining services and distinguishes cancellations from updates.
  * Inventory reservations and completion totals account for every booked service.
* **Notifications**
  * Added alerts when a service is removed from an existing appointment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->