### PR TITLE
fix(appointments): align calendar route timezone

### DIFF
--- a/src/calendar/index.ts
+++ b/src/calendar/index.ts
@@ -1,4 +1,7 @@
 export { AppointmentsCalendar } from "./calendar";
 export { CALENDAR_VIEWS } from "./constants";
 export type { CalendarView } from "./types";
-export { getRangeDayTimestamps } from "./use-calendar-appointments";
+export {
+  getCalendarDayTimestamp,
+  getRangeDayTimestamps,
+} from "./use-calendar-appointments";

--- a/src/components/layout/nav/nav-data.ts
+++ b/src/components/layout/nav/nav-data.ts
@@ -10,7 +10,7 @@ import {
 } from "@phosphor-icons/react";
 import { useCallback } from "react";
 
-import { startOfDay } from "@/lib/utils";
+import { getCalendarDayTimestamp } from "@/calendar/use-calendar-appointments";
 import { useLocationStore } from "@/store/barbershop-filters";
 
 export interface MobileMenuItem {
@@ -69,7 +69,8 @@ export function useNavSearch() {
         return { tab: "account" } as const;
       }
       if (to === "/profile/barbershops/appointments") {
-        return { date: startOfDay(Date.now()).getTime() };
+        // Bogotá day: the calendar route normalizes `date` to that zone.
+        return { date: getCalendarDayTimestamp(new Date()) };
       }
       if (to === "/barbershops") {
         return { city: persistedCity, state: persistedState };

--- a/src/components/notifications/appointment-hub-link.ts
+++ b/src/components/notifications/appointment-hub-link.ts
@@ -1,14 +1,10 @@
+import { getCalendarDayTimestamp } from "@/calendar/use-calendar-appointments";
+
 /** Search params for `/profile` when opening the customer Citas tab. */
 export type CustomerAppointmentsSearch = { tab: "appointments" };
 
 /** Search params for `/profile/barbershops/appointments` (barber calendar). */
 export type BarberCalendarSearch = { date: number };
-
-function startOfLocalDayMs(referenceMs: number = Date.now()): number {
-  const d = new Date(referenceMs);
-  d.setHours(0, 0, 0, 0);
-  return d.getTime();
-}
 
 /**
  * Where to send someone for “everything about appointments”:
@@ -20,9 +16,11 @@ export function getAppointmentHubLink(usesBarberCalendar: boolean): {
   search: CustomerAppointmentsSearch | BarberCalendarSearch;
 } {
   if (usesBarberCalendar) {
+    // The calendar route reads `date` as a Bogotá day; a local midnight from
+    // another zone would land on the wrong day.
     return {
       to: "/profile/barbershops/appointments",
-      search: { date: startOfLocalDayMs() },
+      search: { date: getCalendarDayTimestamp(new Date()) },
     };
   }
   return {

--- a/src/routes/_authedRoutes/profile/barbershops/appointments/index.tsx
+++ b/src/routes/_authedRoutes/profile/barbershops/appointments/index.tsx
@@ -8,6 +8,7 @@ import { z } from "zod";
 import {
   AppointmentsCalendar,
   CALENDAR_VIEWS,
+  getCalendarDayTimestamp,
   getRangeDayTimestamps,
 } from "@/calendar";
 import { rescheduledAppointmentRequestsTableColumns } from "@/components/appointments/table/columns";
@@ -67,11 +68,7 @@ const searchSchema = z.object({
     .number()
     .optional()
     .default(() => Date.now())
-    .transform((val) => {
-      const startOfDay = new Date(val);
-      startOfDay.setHours(0, 0, 0, 0);
-      return startOfDay.getTime();
-    }),
+    .transform((value) => getCalendarDayTimestamp(new Date(value))),
   view: z.enum(CALENDAR_VIEWS).optional().default("week"),
 });
 
@@ -281,7 +278,7 @@ function AppointmentsPending() {
           </div>
           <Skeleton className="h-8 w-64" />
         </div>
-        <Skeleton className="h-[60vh] w-full rounded-xl" />
+        <Skeleton className="h-[70vh] max-h-[56rem] min-h-[32rem] w-full rounded-xl" />
       </div>
 
       <div className="space-y-3">


### PR DESCRIPTION
## Summary
- normalize calendar search dates to midnight in America/Bogota
- keep route prefetch ranges aligned with the ReUI visible range
- match the pending calendar skeleton to the contained calendar height

## Validation
- `pnpm exec tsc --noEmit`
- Biome check on all touched files
- `pnpm doctor:diff` (86/100 Great; no bug or accessibility findings)
- `pnpm build`

## Stack
1. #97 migrates the appointment calendar to ReUI
2. This PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved appointment date handling to consistently use the Bogotá calendar day.
  * Fixed barber calendar navigation and notification links to open on the correct date across time zones.
  * Updated the pending appointments loading state with more responsive sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->